### PR TITLE
Rename baseOperation to baseOperator

### DIFF
--- a/pkg/operator/base.go
+++ b/pkg/operator/base.go
@@ -11,15 +11,15 @@ const (
 	afterFieldDiff  = "after"
 )
 
-type BaseOperationOption Option[baseOperation]
+type BaseOperatorOption Option[baseOperator]
 
-func WithCustomLogger(logger *logrus.Logger) BaseOperationOption {
-	return func(b *baseOperation) {
+func WithCustomLogger(logger *logrus.Logger) BaseOperatorOption {
+	return func(b *baseOperator) {
 		b.loggerInstance = logger
 	}
 }
 
-type baseOperation struct {
+type baseOperator struct {
 	arguments      OperatorArguments
 	resources      map[string]any
 	loggerInstance *logrus.Logger
@@ -29,9 +29,9 @@ type baseOperation struct {
 func newBaseOperator(
 	operationID string,
 	arguments OperatorArguments,
-	options ...BaseOperationOption,
-) baseOperation {
-	base := &baseOperation{
+	options ...BaseOperatorOption,
+) baseOperator {
+	base := &baseOperator{
 		arguments:      arguments,
 		resources:      make(map[string]any),
 		loggerInstance: logrus.StandardLogger(),
@@ -46,7 +46,7 @@ func newBaseOperator(
 	return *base
 }
 
-func (b *baseOperation) standardDiff(_ context.Context) map[string]any {
+func (b *baseOperator) standardDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 	diff["before"] = b.resources[beforeDiffField]
 	diff["after"] = b.resources[afterFieldDiff]

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -21,6 +21,6 @@ type Operator interface {
 }
 
 type OperatorOptions[T any] struct {
-	BaseOperatorOptions []BaseOperationOption
+	BaseOperatorOptions []BaseOperatorOption
 	OperatorOptions     []Option[T]
 }

--- a/pkg/operator/registry.go
+++ b/pkg/operator/registry.go
@@ -96,7 +96,7 @@ func (m *Registry) getLatestVersionForOperator(name string) (string, error) {
 	return versions[len(versions)-1], nil
 }
 
-func StandardRegistry(options ...BaseOperationOption) *Registry {
+func StandardRegistry(options ...BaseOperatorOption) *Registry {
 	return &Registry{
 		operators: OperatorBuildersTree{
 			SaptuneApplySolutionOperatorName: map[string]OperatorBuilder{

--- a/pkg/operator/saptuneapplysolution_v1.go
+++ b/pkg/operator/saptuneapplysolution_v1.go
@@ -49,7 +49,7 @@ type saptuneApplySolutionArguments struct {
 //   to undo the applied solution.
 
 type SaptuneApplySolution struct {
-	baseOperation
+	baseOperator
 	executor        support.CmdExecutor
 	parsedArguments *saptuneApplySolutionArguments
 }
@@ -66,8 +66,8 @@ func NewSaptuneApplySolution(
 	options OperatorOptions[SaptuneApplySolution],
 ) *Executor {
 	saptuneApply := &SaptuneApplySolution{
-		baseOperation: newBaseOperator(operationID, arguments, options.BaseOperatorOptions...),
-		executor:      support.CliExecutor{},
+		baseOperator: newBaseOperator(operationID, arguments, options.BaseOperatorOptions...),
+		executor:     support.CliExecutor{},
 	}
 
 	for _, opt := range options.OperatorOptions {


### PR DESCRIPTION
# Description

Simple renaming of `baseOperation` to `baseOperator`. It looks more appropriate