### PR TITLE
Cluster maintenance change

### DIFF
--- a/pkg/operator/clustermaintenancechange_v1.go
+++ b/pkg/operator/clustermaintenancechange_v1.go
@@ -1,0 +1,338 @@
+package operator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/trento-project/workbench/internal/support"
+)
+
+const (
+	ClusterMaintenanceChangeOperatorName = "clustermaintenancechange"
+	clusterIdlePattern                   = "S_IDLE"
+	maintenanceOn                        = "on"
+	maintenanceOff                       = "off"
+)
+
+var (
+	clusterIdlePatternCompiled = regexp.MustCompile(clusterIdlePattern)
+)
+
+type ClusterMaintenanceChangeOption Option[ClusterMaintenanceChange]
+
+type clusterMaintenanceChangeArguments struct {
+	maintenance bool
+	resourceID  string
+}
+
+type diffOutput struct {
+	Maintenance bool   `json:"maintenance"`
+	ResourceID  string `json:"resource_id,omitempty"`
+}
+
+// ClusterMaintenanceChange is an operator responsible for changing cluster maintenance
+// and cluster resources managed state. `crmsh` is the used to tool to apply the write and most of
+// the read operations in the cluster.
+// The used commands differ if the the state to change is of the whole cluster or a particular resource.
+//
+// Find some helpful references about maintenance transitions and used commands:
+// - https://www.suse.com/c/sles-for-sap-hana-maintenance-procedures-part-1-pre-maintenance-checks/
+// - https://crmsh.github.io/man-4.6/
+// - https://crmsh.github.io/man-4.6/#cmdhelp_root_status
+// - https://crmsh.github.io/man-4.6/#cmdhelp_maintenance
+// - https://crmsh.github.io/man-4.6/#cmdhelp_resource
+//
+// The operator accepts the next arguments:
+// - maintenance (bool): The desired maintenance state for the cluster or cluster resource.
+//                       If true, the cluster or cluster resource are set in maintenance mode.
+// - resource_id (string): If given, the operator changes the maintenance state of the resource.
+//                         Otherwise, it changes the general maintenance state of the cluster.
+//
+// # Execution Phases
+//
+// - PLAN:
+//   Check if a pacemaker cluster is present and store the current state.
+//
+// - COMMIT:
+//   Change the cluster or cluster resource state if the cluster is in IDLE state.
+//   If the maintenance state is removed, the cluster resource state is refreshed.
+//
+// - VERIFY:
+//   Check if the cluster or cluster resource maintenance state has the expected value and
+//   store the final state.
+//
+// - ROLLBACK:
+//   Change the cluster or cluster resource state to the initial state if the cluster
+//   is in IDLE state.
+
+type ClusterMaintenanceChange struct {
+	baseOperator
+	executor        support.CmdExecutor
+	parsedArguments *clusterMaintenanceChangeArguments
+}
+
+func WithCustomExecutor(executor support.CmdExecutor) ClusterMaintenanceChangeOption {
+	return func(o *ClusterMaintenanceChange) {
+		o.executor = executor
+	}
+}
+
+func NewClusterMaintenanceChange(
+	arguments OperatorArguments,
+	operationID string,
+	options OperatorOptions[ClusterMaintenanceChange],
+) *Executor {
+	clusterMaintenance := &ClusterMaintenanceChange{
+		baseOperator: newBaseOperator(operationID, arguments, options.BaseOperatorOptions...),
+		executor:     support.CliExecutor{},
+	}
+
+	for _, opt := range options.OperatorOptions {
+		opt(clusterMaintenance)
+	}
+
+	return &Executor{
+		phaser:      clusterMaintenance,
+		operationID: operationID,
+	}
+}
+
+func (c *ClusterMaintenanceChange) plan(ctx context.Context) error {
+	opArguments, err := parseClusterMaintenanceArguments(c.arguments)
+	if err != nil {
+		return err
+	}
+	c.parsedArguments = opArguments
+
+	// check if a cluster is available and running
+	_, err = c.executor.Exec(ctx, "crm", "status")
+	if err != nil {
+		return fmt.Errorf("error getting cluster status: %w", err)
+	}
+
+	currentState, err := getMaintenanceState(ctx, c.executor, c.parsedArguments.resourceID)
+	if err != nil {
+		return err
+	}
+
+	c.resources[beforeDiffField] = currentState
+
+	return nil
+}
+
+func (c *ClusterMaintenanceChange) commit(ctx context.Context) error {
+	if c.resources[beforeDiffField] == c.parsedArguments.maintenance {
+		c.logger.Infof("maintenance state %v already set, skipping operation", c.parsedArguments.maintenance)
+		return nil
+	}
+
+	err := isIdle(ctx, c.executor)
+	if err != nil {
+		return err
+	}
+
+	// refresh cluster or resource before removing maintenance state
+	if !c.parsedArguments.maintenance {
+		_, err = c.executor.Exec(ctx, "crm", "resource", "refresh", c.parsedArguments.resourceID)
+		if err != nil {
+			return fmt.Errorf("error updating maintenance state: %w", err)
+		}
+	}
+
+	state := maintenanceStateString(c.parsedArguments.maintenance)
+
+	_, err = c.executor.Exec(ctx, "crm", "maintenance", state, c.parsedArguments.resourceID)
+	if err != nil {
+		return fmt.Errorf("error updating maintenance state: %w", err)
+	}
+
+	return nil
+}
+
+func (c *ClusterMaintenanceChange) verify(ctx context.Context) error {
+	currentState, err := getMaintenanceState(ctx, c.executor, c.parsedArguments.resourceID)
+	if err != nil {
+		return err
+	}
+
+	if c.parsedArguments.maintenance == currentState {
+		c.resources[afterFieldDiff] = currentState
+		return nil
+	}
+
+	return fmt.Errorf(
+		"verify cluster maintenance failed, the maintenance value %v was not set in commit phase",
+		c.parsedArguments.maintenance,
+	)
+}
+
+func (c *ClusterMaintenanceChange) rollback(ctx context.Context) error {
+	err := isIdle(ctx, c.executor)
+	if err != nil {
+		return err
+	}
+
+	initialState, _ := c.resources[beforeDiffField].(bool)
+	state := maintenanceStateString(initialState)
+
+	_, err = c.executor.Exec(ctx, "crm", "maintenance", state, c.parsedArguments.resourceID)
+	if err != nil {
+		return fmt.Errorf("error rolling back maintenance state: %w", err)
+	}
+
+	return nil
+}
+
+func (c *ClusterMaintenanceChange) operationDiff(ctx context.Context) map[string]any {
+	diff := make(map[string]any)
+
+	beforeDiffOutput := diffOutput{
+		Maintenance: c.resources[beforeDiffField].(bool),
+		ResourceID:  c.parsedArguments.resourceID,
+	}
+	before, _ := json.Marshal(beforeDiffOutput)
+	diff["before"] = string(before)
+
+	afterDiffOutput := diffOutput{
+		Maintenance: c.resources[afterFieldDiff].(bool),
+		ResourceID:  c.parsedArguments.resourceID,
+	}
+	after, _ := json.Marshal(afterDiffOutput)
+	diff["after"] = string(after)
+
+	return diff
+}
+
+// getMaintanceState returns the current state of the cluster
+// Find additional information here:
+// https://clusterlabs.org/projects/pacemaker/doc/2.1/Pacemaker_Explained/html/resources.html#resource-meta-attributes
+func getMaintenanceState(ctx context.Context, executor support.CmdExecutor, resourceID string) (bool, error) {
+	// general cluster state
+	if len(resourceID) == 0 {
+		maintenanceMode, err := executor.Exec(ctx, "crm", "configure", "get_property", "-t", "maintenance-mode")
+		if err != nil {
+			return false, fmt.Errorf("error getting maintenance-mode: %w", err)
+		}
+
+		boolValue, err := parseStateOutput(maintenanceMode)
+		if err != nil {
+			return false, fmt.Errorf("error decoding maintenance-mode attribute: %w", err)
+		}
+
+		return boolValue, nil
+	}
+
+	// specific resource state
+	// get "maintenance" attribute of the resource. This has preference over is-managed attribute
+	output, err := executor.Exec(ctx, "crm", "resource", "meta", resourceID, "show", "maintenance")
+	if err != nil {
+		return false, fmt.Errorf("error getting maintenance attribute: %w", err)
+	}
+
+	if !strings.Contains(string(output), "not found") {
+		boolValue, err := parseStateOutput(output)
+		if err != nil {
+			return false, fmt.Errorf("error decoding maintenance attribute: %w", err)
+		}
+
+		return boolValue, nil
+	}
+
+	// get "is-managed" attribute of the resource
+	output, err = executor.Exec(ctx, "crm", "resource", "meta", resourceID, "show", "is-managed")
+	if err != nil {
+		return false, fmt.Errorf("error getting is-managed attribute: %w", err)
+	}
+
+	// none of maintenance or is-managed attributes found. Defaulting to not in maintenance
+	if strings.Contains(string(output), "not found") {
+		return false, nil
+	}
+
+	boolValue, err := parseStateOutput(output)
+	if err != nil {
+		return false, fmt.Errorf("error decoding is-managed attribute: %w", err)
+	}
+
+	// is-managed has the opposite logic than maintenance attribute
+	return !boolValue, nil
+}
+
+func isIdle(ctx context.Context, executor support.CmdExecutor) error {
+	idleOutput, err := executor.Exec(ctx, "cs_clusterstate", "-i")
+	if err != nil {
+		return fmt.Errorf("error running cs_clusterstate: %w", err)
+	}
+
+	if !clusterIdlePatternCompiled.Match(idleOutput) {
+		return fmt.Errorf("cluster is not in S_IDLE state")
+	}
+
+	return nil
+}
+
+func maintenanceStateString(boolState bool) string {
+	state := maintenanceOff
+	if boolState {
+		state = maintenanceOn
+	}
+
+	return state
+}
+
+// depending on the queried resource, the crm command might print some "debug" lines
+// before returning the actual state of the attribute. That's why it needs some cleanup
+// Example output:
+// linux # crm resource meta msl_SAPHana_PRD_HDB00 show maintenance
+// msl_SAPHana_PRD_HDB00 is active on more than one node, returning the default value for maintenance
+// false
+func parseStateOutput(output []byte) (bool, error) {
+	trimmedString := strings.TrimSpace(string(output))
+	if len(trimmedString) == 0 {
+		return false, fmt.Errorf("empty command output")
+	}
+
+	lines := strings.Split(trimmedString, "\n")
+	lastLine := lines[len(lines)-1]
+
+	boolValue, err := strconv.ParseBool(lastLine)
+	if err != nil {
+		return false, err
+	}
+	return boolValue, nil
+}
+
+func parseClusterMaintenanceArguments(rawArguments OperatorArguments) (*clusterMaintenanceChangeArguments, error) {
+	maintenanceArgument, found := rawArguments["maintenance"]
+	if !found {
+		return nil, errors.New("argument maintenance not provided, could not use the operator")
+	}
+
+	maintenance, ok := maintenanceArgument.(bool)
+	if !ok {
+		return nil, fmt.Errorf(
+			"could not parse maintenance argument as bool, argument provided: %v",
+			maintenanceArgument,
+		)
+	}
+
+	argument, found := rawArguments["resource_id"]
+	if !found {
+		return &clusterMaintenanceChangeArguments{maintenance: maintenance, resourceID: ""}, nil
+	}
+
+	resourceID, ok := argument.(string)
+	if !ok {
+		return nil, fmt.Errorf(
+			"could not parse resource_id argument as string, argument provided: %v",
+			argument,
+		)
+	}
+
+	return &clusterMaintenanceChangeArguments{maintenance: maintenance, resourceID: resourceID}, nil
+}

--- a/pkg/operator/clustermaintenancechange_v1.go
+++ b/pkg/operator/clustermaintenancechange_v1.go
@@ -15,12 +15,22 @@ import (
 const (
 	ClusterMaintenanceChangeOperatorName = "clustermaintenancechange"
 	clusterIdlePattern                   = "S_IDLE"
+	nodeStatePattern                     = "value=(.*)"
 	maintenanceOn                        = "on"
 	maintenanceOff                       = "off"
 )
 
+type clusterMaintenanceScope int
+
+const (
+	clusterScope clusterMaintenanceScope = iota
+	resourceScope
+	nodeScope
+)
+
 var (
 	clusterIdlePatternCompiled = regexp.MustCompile(clusterIdlePattern)
+	nodeStatePatternCompiled   = regexp.MustCompile(nodeStatePattern)
 )
 
 type ClusterMaintenanceChangeOption Option[ClusterMaintenanceChange]
@@ -28,17 +38,19 @@ type ClusterMaintenanceChangeOption Option[ClusterMaintenanceChange]
 type clusterMaintenanceChangeArguments struct {
 	maintenance bool
 	resourceID  string
+	nodeID      string
 }
 
 type diffOutput struct {
 	Maintenance bool   `json:"maintenance"`
 	ResourceID  string `json:"resource_id,omitempty"`
+	NodeID      string `json:"node_id,omitempty"`
 }
 
 // ClusterMaintenanceChange is an operator responsible for changing cluster maintenance
-// and cluster resources managed state. `crmsh` is the used to tool to apply the write and most of
+// ,cluster resources or cluster node managed state. `crmsh` is the tool used to apply the write and most of
 // the read operations in the cluster.
-// The used commands differ if the the state to change is of the whole cluster or a particular resource.
+// The used commands differ if the the state to change is the whole cluster, a particular resource or node.
 //
 // Find some helpful references about maintenance transitions and used commands:
 // - https://www.suse.com/c/sles-for-sap-hana-maintenance-procedures-part-1-pre-maintenance-checks/
@@ -47,12 +59,15 @@ type diffOutput struct {
 // - https://crmsh.github.io/man-4.6/#cmdhelp_root_status
 // - https://crmsh.github.io/man-4.6/#cmdhelp_maintenance
 // - https://crmsh.github.io/man-4.6/#cmdhelp_resource
+// - https://crmsh.github.io/man-4.6/#cmdhelp_node
 //
 // The operator accepts the next arguments:
 // - maintenance (bool): The desired maintenance state for the cluster or cluster resource.
-//                       If true, the cluster or cluster resource are set in maintenance mode.
-// - resource_id (string): If given, the operator changes the maintenance state of the resource.
-//                         Otherwise, it changes the general maintenance state of the cluster.
+//                       If true, the cluster, cluster resource or cluster node are set in maintenance mode.
+// - resource_id (string): If given, the operator changes the maintenance state of the resource. It has precedence over node_id argument.
+// - node_id (string): If given, the operator changes the maintenance state of the node.
+// If resource_id or node_id are not given the operator changes the general maintenance state of the cluster.
+
 //
 // # Execution Phases
 //
@@ -60,20 +75,21 @@ type diffOutput struct {
 //   Check if a pacemaker cluster is present and store the current state.
 //
 // - COMMIT:
-//   Change the cluster or cluster resource state if the cluster is in IDLE state.
-//   If the maintenance state is removed, the cluster resource state is refreshed.
+//   Change the cluster, resource or node state if the cluster is in IDLE state.
+//   If the maintenance state is removed, the cluster state is refreshed.
 //
 // - VERIFY:
-//   Check if the cluster or cluster resource maintenance state has the expected value and
+//   Check if the cluster, resource or node maintenance state has the expected value and
 //   store the final state.
 //
 // - ROLLBACK:
-//   Change the cluster or cluster resource state to the initial state if the cluster
+//   Change the cluster, resource or node state to the initial state if the cluster
 //   is in IDLE state.
 
 type ClusterMaintenanceChange struct {
 	baseOperator
 	executor        support.CmdExecutor
+	scope           clusterMaintenanceScope
 	parsedArguments *clusterMaintenanceChangeArguments
 }
 
@@ -110,13 +126,21 @@ func (c *ClusterMaintenanceChange) plan(ctx context.Context) error {
 	}
 	c.parsedArguments = opArguments
 
+	if c.parsedArguments.resourceID != "" {
+		c.scope = resourceScope
+	} else if c.parsedArguments.nodeID != "" {
+		c.scope = nodeScope
+	} else {
+		c.scope = clusterScope
+	}
+
 	// check if a cluster is available and running
 	_, err = c.executor.Exec(ctx, "crm", "status")
 	if err != nil {
 		return fmt.Errorf("error getting cluster status: %w", err)
 	}
 
-	currentState, err := getMaintenanceState(ctx, c.executor, c.parsedArguments.resourceID)
+	currentState, err := getMaintenanceState(ctx, c.executor, c.scope, c.parsedArguments)
 	if err != nil {
 		return err
 	}
@@ -138,25 +162,23 @@ func (c *ClusterMaintenanceChange) commit(ctx context.Context) error {
 	}
 
 	// refresh cluster or resource before removing maintenance state
+	// in case of node state change, using the command with empty resourceID is OK
 	if !c.parsedArguments.maintenance {
 		_, err = c.executor.Exec(ctx, "crm", "resource", "refresh", c.parsedArguments.resourceID)
 		if err != nil {
-			return fmt.Errorf("error updating maintenance state: %w", err)
+			return fmt.Errorf("error refreshing maintenance state: %w", err)
 		}
 	}
 
-	state := maintenanceStateString(c.parsedArguments.maintenance)
-
-	_, err = c.executor.Exec(ctx, "crm", "maintenance", state, c.parsedArguments.resourceID)
+	err = setMaintenanceState(ctx, c.executor, c.scope, c.parsedArguments.maintenance, c.parsedArguments)
 	if err != nil {
 		return fmt.Errorf("error updating maintenance state: %w", err)
 	}
-
 	return nil
 }
 
 func (c *ClusterMaintenanceChange) verify(ctx context.Context) error {
-	currentState, err := getMaintenanceState(ctx, c.executor, c.parsedArguments.resourceID)
+	currentState, err := getMaintenanceState(ctx, c.executor, c.scope, c.parsedArguments)
 	if err != nil {
 		return err
 	}
@@ -179,13 +201,10 @@ func (c *ClusterMaintenanceChange) rollback(ctx context.Context) error {
 	}
 
 	initialState, _ := c.resources[beforeDiffField].(bool)
-	state := maintenanceStateString(initialState)
-
-	_, err = c.executor.Exec(ctx, "crm", "maintenance", state, c.parsedArguments.resourceID)
+	err = setMaintenanceState(ctx, c.executor, c.scope, initialState, c.parsedArguments)
 	if err != nil {
 		return fmt.Errorf("error rolling back maintenance state: %w", err)
 	}
-
 	return nil
 }
 
@@ -195,6 +214,7 @@ func (c *ClusterMaintenanceChange) operationDiff(ctx context.Context) map[string
 	beforeDiffOutput := diffOutput{
 		Maintenance: c.resources[beforeDiffField].(bool),
 		ResourceID:  c.parsedArguments.resourceID,
+		NodeID:      c.parsedArguments.nodeID,
 	}
 	before, _ := json.Marshal(beforeDiffOutput)
 	diff["before"] = string(before)
@@ -202,6 +222,7 @@ func (c *ClusterMaintenanceChange) operationDiff(ctx context.Context) map[string
 	afterDiffOutput := diffOutput{
 		Maintenance: c.resources[afterFieldDiff].(bool),
 		ResourceID:  c.parsedArguments.resourceID,
+		NodeID:      c.parsedArguments.nodeID,
 	}
 	after, _ := json.Marshal(afterDiffOutput)
 	diff["after"] = string(after)
@@ -212,56 +233,120 @@ func (c *ClusterMaintenanceChange) operationDiff(ctx context.Context) map[string
 // getMaintanceState returns the current state of the cluster
 // Find additional information here:
 // https://clusterlabs.org/projects/pacemaker/doc/2.1/Pacemaker_Explained/html/resources.html#resource-meta-attributes
-func getMaintenanceState(ctx context.Context, executor support.CmdExecutor, resourceID string) (bool, error) {
-	// general cluster state
-	if len(resourceID) == 0 {
-		maintenanceMode, err := executor.Exec(ctx, "crm", "configure", "get_property", "-t", "maintenance-mode")
-		if err != nil {
-			return false, fmt.Errorf("error getting maintenance-mode: %w", err)
+func getMaintenanceState(
+	ctx context.Context,
+	executor support.CmdExecutor,
+	scope clusterMaintenanceScope,
+	args *clusterMaintenanceChangeArguments,
+) (bool, error) {
+	switch scope {
+	case resourceScope:
+		{
+			// get "maintenance" attribute of the resource. This has preference over is-managed attribute
+			output, err := executor.Exec(ctx, "crm", "resource", "meta", args.resourceID, "show", "maintenance")
+			if err != nil {
+				return false, fmt.Errorf("error getting maintenance attribute: %w", err)
+			}
+
+			if !strings.Contains(string(output), "not found") {
+				boolValue, err := parseStateOutput(output)
+				if err != nil {
+					return false, fmt.Errorf("error decoding maintenance attribute: %w", err)
+				}
+
+				return boolValue, nil
+			}
+
+			// get "is-managed" attribute of the resource
+			output, err = executor.Exec(ctx, "crm", "resource", "meta", args.resourceID, "show", "is-managed")
+			if err != nil {
+				return false, fmt.Errorf("error getting is-managed attribute: %w", err)
+			}
+
+			// none of maintenance or is-managed attributes found. Defaulting to not in maintenance
+			if strings.Contains(string(output), "not found") {
+				return false, nil
+			}
+
+			boolValue, err := parseStateOutput(output)
+			if err != nil {
+				return false, fmt.Errorf("error decoding is-managed attribute: %w", err)
+			}
+
+			// is-managed has the opposite logic than maintenance attribute
+			return !boolValue, nil
 		}
+	case nodeScope:
+		{
+			// this command fails if the node is unknown. Check the output to see if the node is recognized
+			// possible outputs:
+			// maintenance on: scope=nodes  name=maintenance value=true
+			// maintenance off: scope=nodes  name=maintenance value=off
+			// yes, it returns true/off instead of true/false, on/off...
+			// node not found output:
+			// Could not map name=node-name to a UUID
+			maintenanceMode, err := executor.Exec(ctx, "crm", "node", "attribute", args.nodeID, "show", "maintenance")
+			if err != nil && strings.Contains(string(maintenanceMode), "Could not map") {
+				return false, fmt.Errorf("error getting node maintenance attribute: %w", err)
+			}
 
-		boolValue, err := parseStateOutput(maintenanceMode)
-		if err != nil {
-			return false, fmt.Errorf("error decoding maintenance-mode attribute: %w", err)
+			values := nodeStatePatternCompiled.FindSubmatch(maintenanceMode)
+			if len(values) == 2 && string(values[1]) == "true" {
+				return true, nil
+			}
+
+			return false, nil
 		}
+	default:
+		{
+			maintenanceMode, err := executor.Exec(ctx, "crm", "configure", "get_property", "-t", "maintenance-mode")
+			if err != nil {
+				return false, fmt.Errorf("error getting maintenance-mode: %w", err)
+			}
 
-		return boolValue, nil
-	}
+			boolValue, err := parseStateOutput(maintenanceMode)
+			if err != nil {
+				return false, fmt.Errorf("error decoding maintenance-mode attribute: %w", err)
+			}
 
-	// specific resource state
-	// get "maintenance" attribute of the resource. This has preference over is-managed attribute
-	output, err := executor.Exec(ctx, "crm", "resource", "meta", resourceID, "show", "maintenance")
-	if err != nil {
-		return false, fmt.Errorf("error getting maintenance attribute: %w", err)
-	}
-
-	if !strings.Contains(string(output), "not found") {
-		boolValue, err := parseStateOutput(output)
-		if err != nil {
-			return false, fmt.Errorf("error decoding maintenance attribute: %w", err)
+			return boolValue, nil
 		}
+	}
+}
 
-		return boolValue, nil
+func setMaintenanceState(
+	ctx context.Context,
+	executor support.CmdExecutor,
+	scope clusterMaintenanceScope,
+	state bool,
+	args *clusterMaintenanceChangeArguments,
+) error {
+	strState := maintenanceOff
+	if state {
+		strState = maintenanceOn
 	}
 
-	// get "is-managed" attribute of the resource
-	output, err = executor.Exec(ctx, "crm", "resource", "meta", resourceID, "show", "is-managed")
-	if err != nil {
-		return false, fmt.Errorf("error getting is-managed attribute: %w", err)
+	switch scope {
+	case resourceScope:
+		{
+			_, err := executor.Exec(ctx, "crm", "maintenance", strState, args.resourceID)
+			return err
+		}
+	case nodeScope:
+		{
+			if state {
+				_, err := executor.Exec(ctx, "crm", "--force", "node", "maintenance", args.nodeID)
+				return err
+			}
+			_, err := executor.Exec(ctx, "crm", "--force", "node", "ready", args.nodeID)
+			return err
+		}
+	default:
+		{
+			_, err := executor.Exec(ctx, "crm", "maintenance", strState)
+			return err
+		}
 	}
-
-	// none of maintenance or is-managed attributes found. Defaulting to not in maintenance
-	if strings.Contains(string(output), "not found") {
-		return false, nil
-	}
-
-	boolValue, err := parseStateOutput(output)
-	if err != nil {
-		return false, fmt.Errorf("error decoding is-managed attribute: %w", err)
-	}
-
-	// is-managed has the opposite logic than maintenance attribute
-	return !boolValue, nil
 }
 
 func isIdle(ctx context.Context, executor support.CmdExecutor) error {
@@ -275,15 +360,6 @@ func isIdle(ctx context.Context, executor support.CmdExecutor) error {
 	}
 
 	return nil
-}
-
-func maintenanceStateString(boolState bool) string {
-	state := maintenanceOff
-	if boolState {
-		state = maintenanceOn
-	}
-
-	return state
 }
 
 // depending on the queried resource, the crm command might print some "debug" lines
@@ -309,6 +385,8 @@ func parseStateOutput(output []byte) (bool, error) {
 }
 
 func parseClusterMaintenanceArguments(rawArguments OperatorArguments) (*clusterMaintenanceChangeArguments, error) {
+	var resourceID, nodeID string
+
 	maintenanceArgument, found := rawArguments["maintenance"]
 	if !found {
 		return nil, errors.New("argument maintenance not provided, could not use the operator")
@@ -322,18 +400,28 @@ func parseClusterMaintenanceArguments(rawArguments OperatorArguments) (*clusterM
 		)
 	}
 
-	argument, found := rawArguments["resource_id"]
-	if !found {
-		return &clusterMaintenanceChangeArguments{maintenance: maintenance, resourceID: ""}, nil
+	// resource_id has preference over node_id
+	if resourceIDArgument, found := rawArguments["resource_id"]; found {
+		resourceID, ok = resourceIDArgument.(string)
+		if !ok {
+			return nil, fmt.Errorf(
+				"could not parse resource_id argument as string, argument provided: %v",
+				resourceIDArgument,
+			)
+		}
+	} else if nodeIDArgument, found := rawArguments["node_id"]; found {
+		nodeID, ok = nodeIDArgument.(string)
+		if !ok {
+			return nil, fmt.Errorf(
+				"could not parse node_id argument as string, argument provided: %v",
+				nodeIDArgument,
+			)
+		}
 	}
 
-	resourceID, ok := argument.(string)
-	if !ok {
-		return nil, fmt.Errorf(
-			"could not parse resource_id argument as string, argument provided: %v",
-			argument,
-		)
-	}
-
-	return &clusterMaintenanceChangeArguments{maintenance: maintenance, resourceID: resourceID}, nil
+	return &clusterMaintenanceChangeArguments{
+		maintenance: maintenance,
+		resourceID:  resourceID,
+		nodeID:      nodeID,
+	}, nil
 }

--- a/pkg/operator/clustermaintenancechange_v1.go
+++ b/pkg/operator/clustermaintenancechange_v1.go
@@ -47,10 +47,10 @@ type diffOutput struct {
 	NodeID      string `json:"node_id,omitempty"`
 }
 
-// ClusterMaintenanceChange is an operator responsible for changing cluster maintenance
-// ,cluster resources or cluster node managed state. `crmsh` is the tool used to apply the write and most of
+// ClusterMaintenanceChange is an operator responsible for changing cluster maintenance,
+// cluster resources or cluster node managed state. `crmsh` is the tool used to apply the write and most of
 // the read operations in the cluster.
-// The used commands differ if the the state to change is the whole cluster, a particular resource or node.
+// The used commands differ if the state to change is the whole cluster, a particular resource or node.
 //
 // Find some helpful references about maintenance transitions and used commands:
 // - https://www.suse.com/c/sles-for-sap-hana-maintenance-procedures-part-1-pre-maintenance-checks/
@@ -363,8 +363,10 @@ func isIdle(ctx context.Context, executor support.CmdExecutor) error {
 	return nil
 }
 
-// depending on the queried resource, the crm command might print some "debug" lines
-// before returning the actual state of the attribute. That's why it needs some cleanup
+// Depending on the queried resource, the crm command might print some "debug" lines
+// before returning the actual state of the attribute.
+// The actual state is always a boolean value, either 'true' or 'false'
+// The debug lines are cleaned up before parsing the final boolean state of the attribute.
 // Example output:
 // linux # crm resource meta msl_SAPHana_PRD_HDB00 show maintenance
 // msl_SAPHana_PRD_HDB00 is active on more than one node, returning the default value for maintenance

--- a/pkg/operator/clustermaintenancechange_v1.go
+++ b/pkg/operator/clustermaintenancechange_v1.go
@@ -77,7 +77,7 @@ type ClusterMaintenanceChange struct {
 	parsedArguments *clusterMaintenanceChangeArguments
 }
 
-func WithCustomExecutor(executor support.CmdExecutor) ClusterMaintenanceChangeOption {
+func WithCustomClusterMaintenanceExecutor(executor support.CmdExecutor) ClusterMaintenanceChangeOption {
 	return func(o *ClusterMaintenanceChange) {
 		o.executor = executor
 	}

--- a/pkg/operator/clustermaintenancechange_v1.go
+++ b/pkg/operator/clustermaintenancechange_v1.go
@@ -42,6 +42,7 @@ type diffOutput struct {
 //
 // Find some helpful references about maintenance transitions and used commands:
 // - https://www.suse.com/c/sles-for-sap-hana-maintenance-procedures-part-1-pre-maintenance-checks/
+// - https://www.suse.com/c/sles-for-sap-hana-maintenance-procedures-part-2-manual-administrative-tasks-os-reboots-and-updation-of-os-and-hana/
 // - https://crmsh.github.io/man-4.6/
 // - https://crmsh.github.io/man-4.6/#cmdhelp_root_status
 // - https://crmsh.github.io/man-4.6/#cmdhelp_maintenance

--- a/pkg/operator/clustermaintenancechange_v1_test.go
+++ b/pkg/operator/clustermaintenancechange_v1_test.go
@@ -257,7 +257,7 @@ func TestClusterMaintenanceChangeResourceWithIsManagedSuccess(t *testing.T) {
 		"maintenance",
 	).Return([]byte("not found"), nil)
 
-	// is-managed has the reverse boolean logic than `maintnance`
+	// is-managed has the reverse boolean logic than `maintenance`
 	// so is-managed=true means maintenance=false
 	mockCmdExecutor.On(
 		"Exec",

--- a/pkg/operator/clustermaintenancechange_v1_test.go
+++ b/pkg/operator/clustermaintenancechange_v1_test.go
@@ -1,0 +1,900 @@
+package operator_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/trento-project/workbench/internal/support/mocks"
+	"github.com/trento-project/workbench/pkg/operator"
+)
+
+func TestClusterMaintenanceChangeSuccessOn(t *testing.T) {
+	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
+	ctx := context.Background()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"status",
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"configure",
+		"get_property",
+		"-t",
+		"maintenance-mode",
+	).Return([]byte("false"), nil).Once()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"cs_clusterstate",
+		"-i",
+	).Return([]byte("S_IDLE"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"maintenance",
+		"on",
+		"",
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"configure",
+		"get_property",
+		"-t",
+		"maintenance-mode",
+	).Return([]byte("true"), nil)
+
+	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
+		operator.OperatorArguments{
+			"maintenance": true,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+			},
+		},
+	)
+
+	report := clusterMaintenanceChangeOperator.Run(ctx)
+
+	expectedDiff := map[string]any{
+		"before": "{\"maintenance\":false}",
+		"after":  "{\"maintenance\":true}",
+	}
+
+	assert.Nil(t, report.Error)
+	assert.Equal(t, report.Success.LastPhase, operator.VERIFY)
+	assert.EqualValues(t, report.Success.Diff, expectedDiff)
+}
+
+func TestClusterMaintenanceChangeSuccessOff(t *testing.T) {
+	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
+	ctx := context.Background()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"status",
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"configure",
+		"get_property",
+		"-t",
+		"maintenance-mode",
+	).Return([]byte("true"), nil).Once()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"cs_clusterstate",
+		"-i",
+	).Return([]byte("S_IDLE"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"resource",
+		"refresh",
+		"",
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"maintenance",
+		"off",
+		"",
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"configure",
+		"get_property",
+		"-t",
+		"maintenance-mode",
+	).Return([]byte("false"), nil)
+
+	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
+		operator.OperatorArguments{
+			"maintenance": false,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+			},
+		},
+	)
+
+	report := clusterMaintenanceChangeOperator.Run(ctx)
+
+	expectedDiff := map[string]any{
+		"before": "{\"maintenance\":true}",
+		"after":  "{\"maintenance\":false}",
+	}
+
+	assert.Nil(t, report.Error)
+	assert.Equal(t, report.Success.LastPhase, operator.VERIFY)
+	assert.EqualValues(t, report.Success.Diff, expectedDiff)
+}
+
+func TestClusterMaintenanceChangeResourceSuccess(t *testing.T) {
+	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
+	ctx := context.Background()
+	resourceID := "some-id"
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"status",
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"resource",
+		"meta",
+		resourceID,
+		"show",
+		"maintenance",
+	).Return([]byte("false"), nil).Once()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"cs_clusterstate",
+		"-i",
+	).Return([]byte("S_IDLE"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"maintenance",
+		"on",
+		resourceID,
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"resource",
+		"meta",
+		resourceID,
+		"show",
+		"maintenance",
+	).Return([]byte("true"), nil)
+
+	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
+		operator.OperatorArguments{
+			"maintenance": true,
+			"resource_id": resourceID,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+			},
+		},
+	)
+
+	report := clusterMaintenanceChangeOperator.Run(ctx)
+
+	expectedDiff := map[string]any{
+		"before": "{\"maintenance\":false,\"resource_id\":\"some-id\"}",
+		"after":  "{\"maintenance\":true,\"resource_id\":\"some-id\"}",
+	}
+
+	assert.Nil(t, report.Error)
+	assert.Equal(t, report.Success.LastPhase, operator.VERIFY)
+	assert.EqualValues(t, report.Success.Diff, expectedDiff)
+}
+
+func TestClusterMaintenanceChangeResourceWithIsManagedSuccess(t *testing.T) {
+	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
+	ctx := context.Background()
+	resourceID := "some-id"
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"status",
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"resource",
+		"meta",
+		resourceID,
+		"show",
+		"maintenance",
+	).Return([]byte("not found"), nil)
+
+	// is-managed has the reverse boolean logic than `maintnance`
+	// so is-managed=true means maintenance=false
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"resource",
+		"meta",
+		resourceID,
+		"show",
+		"is-managed",
+	).Return([]byte("true"), nil).Once()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"cs_clusterstate",
+		"-i",
+	).Return([]byte("S_IDLE"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"maintenance",
+		"on",
+		resourceID,
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"resource",
+		"meta",
+		resourceID,
+		"show",
+		"is-managed",
+	).Return([]byte("false"), nil)
+
+	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
+		operator.OperatorArguments{
+			"maintenance": true,
+			"resource_id": resourceID,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+			},
+		},
+	)
+
+	report := clusterMaintenanceChangeOperator.Run(ctx)
+
+	expectedDiff := map[string]any{
+		"before": "{\"maintenance\":false,\"resource_id\":\"some-id\"}",
+		"after":  "{\"maintenance\":true,\"resource_id\":\"some-id\"}",
+	}
+
+	assert.Nil(t, report.Error)
+	assert.Equal(t, report.Success.LastPhase, operator.VERIFY)
+	assert.EqualValues(t, report.Success.Diff, expectedDiff)
+}
+
+func TestClusterMaintenanceChangeResourceDefaultSuccess(t *testing.T) {
+	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
+	ctx := context.Background()
+	resourceID := "some-id"
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"status",
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"resource",
+		"meta",
+		resourceID,
+		"show",
+		"maintenance",
+	).Return([]byte("not found"), nil).Once()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"resource",
+		"meta",
+		resourceID,
+		"show",
+		"is-managed",
+	).Return([]byte("not found"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"cs_clusterstate",
+		"-i",
+	).Return([]byte("S_IDLE"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"maintenance",
+		"on",
+		resourceID,
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"resource",
+		"meta",
+		resourceID,
+		"show",
+		"maintenance",
+	).Return([]byte("true"), nil)
+
+	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
+		operator.OperatorArguments{
+			"maintenance": true,
+			"resource_id": resourceID,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+			},
+		},
+	)
+
+	report := clusterMaintenanceChangeOperator.Run(ctx)
+
+	expectedDiff := map[string]any{
+		"before": "{\"maintenance\":false,\"resource_id\":\"some-id\"}",
+		"after":  "{\"maintenance\":true,\"resource_id\":\"some-id\"}",
+	}
+
+	assert.Nil(t, report.Error)
+	assert.Equal(t, report.Success.LastPhase, operator.VERIFY)
+	assert.EqualValues(t, report.Success.Diff, expectedDiff)
+}
+
+func TestClusterMaintenanceChangeMissingArgument(t *testing.T) {
+	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
+	ctx := context.Background()
+
+	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
+		operator.OperatorArguments{},
+		"test-op",
+		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+			},
+		},
+	)
+
+	report := clusterMaintenanceChangeOperator.Run(ctx)
+
+	assert.Nil(t, report.Success)
+	assert.Equal(t, report.Error.ErrorPhase, operator.PLAN)
+	assert.EqualValues(t, "argument maintenance not provided, could not use the operator", report.Error.Message)
+}
+
+func TestClusterMaintenanceChangeInvalidArgument(t *testing.T) {
+	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
+	ctx := context.Background()
+
+	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
+		operator.OperatorArguments{
+			"maintenance": "on",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+			},
+		},
+	)
+
+	report := clusterMaintenanceChangeOperator.Run(ctx)
+
+	assert.Nil(t, report.Success)
+	assert.Equal(t, report.Error.ErrorPhase, operator.PLAN)
+	assert.EqualValues(t, "could not parse maintenance argument as bool, argument provided: on", report.Error.Message)
+}
+
+func TestClusterMaintenanceChangeInvalidResourceIDArgument(t *testing.T) {
+	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
+	ctx := context.Background()
+
+	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
+		operator.OperatorArguments{
+			"maintenance": true,
+			"resource_id": 1,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+			},
+		},
+	)
+
+	report := clusterMaintenanceChangeOperator.Run(ctx)
+
+	assert.Nil(t, report.Success)
+	assert.Equal(t, report.Error.ErrorPhase, operator.PLAN)
+	assert.EqualValues(t, "could not parse resource_id argument as string, argument provided: 1", report.Error.Message)
+}
+
+func TestClusterMaintenanceChangePlanClusterNotFound(t *testing.T) {
+	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
+	ctx := context.Background()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"status",
+	).Return([]byte("error"), errors.New("cluster not found"))
+
+	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
+		operator.OperatorArguments{
+			"maintenance": true,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+			},
+		},
+	)
+
+	report := clusterMaintenanceChangeOperator.Run(ctx)
+
+	assert.Nil(t, report.Success)
+	assert.Equal(t, report.Error.ErrorPhase, operator.PLAN)
+	assert.EqualValues(t, "error getting cluster status: cluster not found", report.Error.Message)
+}
+
+func TestClusterMaintenanceChangePlanGetMaintenanceError(t *testing.T) {
+	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
+	ctx := context.Background()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"status",
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"configure",
+		"get_property",
+		"-t",
+		"maintenance-mode",
+	).Return([]byte("error"), errors.New("cannot get state"))
+
+	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
+		operator.OperatorArguments{
+			"maintenance": true,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+			},
+		},
+	)
+
+	report := clusterMaintenanceChangeOperator.Run(ctx)
+
+	assert.Nil(t, report.Success)
+	assert.Equal(t, report.Error.ErrorPhase, operator.PLAN)
+	assert.EqualValues(t, "error getting maintenance-mode: cannot get state", report.Error.Message)
+}
+
+func TestClusterMaintenanceChangePlanEmptyMaintenanceState(t *testing.T) {
+	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
+	ctx := context.Background()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"status",
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"configure",
+		"get_property",
+		"-t",
+		"maintenance-mode",
+	).Return([]byte(""), nil)
+
+	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
+		operator.OperatorArguments{
+			"maintenance": true,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+			},
+		},
+	)
+
+	report := clusterMaintenanceChangeOperator.Run(ctx)
+
+	assert.Nil(t, report.Success)
+	assert.Equal(t, report.Error.ErrorPhase, operator.PLAN)
+	assert.EqualValues(t, "error decoding maintenance-mode attribute: empty command output", report.Error.Message)
+}
+
+func TestClusterMaintenanceChangeCommitAlreadyApplied(t *testing.T) {
+	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
+	ctx := context.Background()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"status",
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"configure",
+		"get_property",
+		"-t",
+		"maintenance-mode",
+	).Return([]byte("true"), nil)
+
+	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
+		operator.OperatorArguments{
+			"maintenance": true,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+			},
+		},
+	)
+
+	report := clusterMaintenanceChangeOperator.Run(ctx)
+
+	expectedDiff := map[string]any{
+		"before": "{\"maintenance\":true}",
+		"after":  "{\"maintenance\":true}",
+	}
+
+	assert.Nil(t, report.Error)
+	assert.Equal(t, report.Success.LastPhase, operator.VERIFY)
+	assert.EqualValues(t, report.Success.Diff, expectedDiff)
+}
+
+func TestClusterMaintenanceChangeCommitNotIdle(t *testing.T) {
+	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
+	ctx := context.Background()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"status",
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"configure",
+		"get_property",
+		"-t",
+		"maintenance-mode",
+	).Return([]byte("false"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"cs_clusterstate",
+		"-i",
+	).Return([]byte("S_TRANSITION"), nil).Once()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"cs_clusterstate",
+		"-i",
+	).Return([]byte("S_IDLE"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"maintenance",
+		"off",
+		"",
+	).Return([]byte("ok"), nil)
+
+	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
+		operator.OperatorArguments{
+			"maintenance": true,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+			},
+		},
+	)
+
+	report := clusterMaintenanceChangeOperator.Run(ctx)
+
+	assert.Nil(t, report.Success)
+	assert.Equal(t, report.Error.ErrorPhase, operator.COMMIT)
+	assert.EqualValues(t, "cluster is not in S_IDLE state", report.Error.Message)
+}
+
+func TestClusterMaintenanceChangeVerifyError(t *testing.T) {
+	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
+	ctx := context.Background()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"status",
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"configure",
+		"get_property",
+		"-t",
+		"maintenance-mode",
+	).Return([]byte("false"), nil).Once()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"cs_clusterstate",
+		"-i",
+	).Return([]byte("S_IDLE"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"maintenance",
+		"on",
+		"",
+	).Return([]byte("ok"), nil).Once()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"configure",
+		"get_property",
+		"-t",
+		"maintenance-mode",
+	).Return([]byte("false"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"maintenance",
+		"off",
+		"",
+	).Return([]byte("ok"), nil)
+
+	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
+		operator.OperatorArguments{
+			"maintenance": true,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+			},
+		},
+	)
+
+	report := clusterMaintenanceChangeOperator.Run(ctx)
+
+	assert.Nil(t, report.Success)
+	assert.Equal(t, report.Error.ErrorPhase, operator.VERIFY)
+	assert.EqualValues(t, "verify cluster maintenance failed, the maintenance value true was not set in commit phase", report.Error.Message)
+}
+
+func TestClusterMaintenanceChangeRollbackNotIdle(t *testing.T) {
+	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
+	ctx := context.Background()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"status",
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"configure",
+		"get_property",
+		"-t",
+		"maintenance-mode",
+	).Return([]byte("false"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"cs_clusterstate",
+		"-i",
+	).Return([]byte("S_IDLE"), nil).Once()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"maintenance",
+		"on",
+		"",
+	).Return([]byte("error"), errors.New("error changing"))
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"cs_clusterstate",
+		"-i",
+	).Return([]byte("S_TRANSITION"), nil)
+
+	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
+		operator.OperatorArguments{
+			"maintenance": true,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+			},
+		},
+	)
+
+	report := clusterMaintenanceChangeOperator.Run(ctx)
+
+	assert.Nil(t, report.Success)
+	assert.Equal(t, report.Error.ErrorPhase, operator.ROLLBACK)
+	assert.EqualValues(t, "cluster is not in S_IDLE state\nerror updating maintenance state: error changing", report.Error.Message)
+}
+
+func TestClusterMaintenanceChangeRollbackErrorReverting(t *testing.T) {
+	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
+	ctx := context.Background()
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"status",
+	).Return([]byte("ok"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"configure",
+		"get_property",
+		"-t",
+		"maintenance-mode",
+	).Return([]byte("false"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"cs_clusterstate",
+		"-i",
+	).Return([]byte("S_IDLE"), nil)
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"maintenance",
+		"on",
+		"",
+	).Return([]byte("error"), errors.New("error changing"))
+
+	mockCmdExecutor.On(
+		"Exec",
+		ctx,
+		"crm",
+		"maintenance",
+		"off",
+		"",
+	).Return([]byte("error"), errors.New("error reverting"))
+
+	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
+		operator.OperatorArguments{
+			"maintenance": true,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+			},
+		},
+	)
+
+	report := clusterMaintenanceChangeOperator.Run(ctx)
+
+	assert.Nil(t, report.Success)
+	assert.Equal(t, report.Error.ErrorPhase, operator.ROLLBACK)
+	assert.EqualValues(t, "error rolling back maintenance state: error reverting\nerror updating maintenance state: error changing", report.Error.Message)
+}

--- a/pkg/operator/clustermaintenancechange_v1_test.go
+++ b/pkg/operator/clustermaintenancechange_v1_test.go
@@ -64,7 +64,7 @@ func TestClusterMaintenanceChangeSuccessOn(t *testing.T) {
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
-				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
 		},
 	)
@@ -144,7 +144,7 @@ func TestClusterMaintenanceChangeSuccessOff(t *testing.T) {
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
-				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
 		},
 	)
@@ -219,7 +219,7 @@ func TestClusterMaintenanceChangeResourceSuccess(t *testing.T) {
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
-				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
 		},
 	)
@@ -307,7 +307,7 @@ func TestClusterMaintenanceChangeResourceWithIsManagedSuccess(t *testing.T) {
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
-				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
 		},
 	)
@@ -393,7 +393,7 @@ func TestClusterMaintenanceChangeResourceDefaultSuccess(t *testing.T) {
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
-				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
 		},
 	)
@@ -419,7 +419,7 @@ func TestClusterMaintenanceChangeMissingArgument(t *testing.T) {
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
-				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
 		},
 	)
@@ -442,7 +442,7 @@ func TestClusterMaintenanceChangeInvalidArgument(t *testing.T) {
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
-				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
 		},
 	)
@@ -466,7 +466,7 @@ func TestClusterMaintenanceChangeInvalidResourceIDArgument(t *testing.T) {
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
-				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
 		},
 	)
@@ -496,7 +496,7 @@ func TestClusterMaintenanceChangePlanClusterNotFound(t *testing.T) {
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
-				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
 		},
 	)
@@ -536,7 +536,7 @@ func TestClusterMaintenanceChangePlanGetMaintenanceError(t *testing.T) {
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
-				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
 		},
 	)
@@ -576,7 +576,7 @@ func TestClusterMaintenanceChangePlanEmptyMaintenanceState(t *testing.T) {
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
-				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
 		},
 	)
@@ -616,7 +616,7 @@ func TestClusterMaintenanceChangeCommitAlreadyApplied(t *testing.T) {
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
-				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
 		},
 	)
@@ -684,7 +684,7 @@ func TestClusterMaintenanceChangeCommitNotIdle(t *testing.T) {
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
-				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
 		},
 	)
@@ -759,7 +759,7 @@ func TestClusterMaintenanceChangeVerifyError(t *testing.T) {
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
-				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
 		},
 	)
@@ -822,7 +822,7 @@ func TestClusterMaintenanceChangeRollbackNotIdle(t *testing.T) {
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
-				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
 		},
 	)
@@ -887,7 +887,7 @@ func TestClusterMaintenanceChangeRollbackErrorReverting(t *testing.T) {
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
-				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomExecutor(mockCmdExecutor)),
+				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
 		},
 	)

--- a/pkg/operator/registry.go
+++ b/pkg/operator/registry.go
@@ -99,6 +99,13 @@ func (m *Registry) getLatestVersionForOperator(name string) (string, error) {
 func StandardRegistry(options ...BaseOperatorOption) *Registry {
 	return &Registry{
 		operators: OperatorBuildersTree{
+			ClusterMaintenanceChangeOperatorName: map[string]OperatorBuilder{
+				"v1": func(operationID string, arguments OperatorArguments) Operator {
+					return NewClusterMaintenanceChange(arguments, operationID, OperatorOptions[ClusterMaintenanceChange]{
+						BaseOperatorOptions: options,
+					})
+				},
+			},
 			SaptuneApplySolutionOperatorName: map[string]OperatorBuilder{
 				"v1": func(operationID string, arguments OperatorArguments) Operator {
 					return NewSaptuneApplySolution(arguments, operationID, OperatorOptions[SaptuneApplySolution]{


### PR DESCRIPTION
# Description

Clueste maintenance change operator.
The operator changes the maintenance state of the cluster or of one resource of the cluster.
The process is similar on both cases.

I tried to document everything in code, so let me know if something is difficult to understand.
The operator usage requires some knowledge of `crmsh` utility, which is used to operate the cluster.

PD: I'm don't like much the way the options are given to the operator. For example, many of the operators will use the command line, and having `WithCustomExecutor` with different names for each of them looks a bummer...
There are some few options with generics, but most of them are pretty ugly or really verbose to use. @CDimonaco any idea on how we could improve this?
