### PR TITLE
lift starndard diff to baseOperator

### DIFF
--- a/pkg/operator/base.go
+++ b/pkg/operator/base.go
@@ -46,10 +46,10 @@ func newBaseOperator(
 	return *base
 }
 
-func (b *baseOperator) standardDiff(_ context.Context) map[string]any {
+func (b *baseOperator) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
-	diff["before"] = b.resources[beforeDiffField]
-	diff["after"] = b.resources[afterFieldDiff]
+	diff[beforeDiffField] = b.resources[beforeDiffField]
+	diff[afterFieldDiff] = b.resources[afterFieldDiff]
 
 	return diff
 }

--- a/pkg/operator/base.go
+++ b/pkg/operator/base.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	beforeDiffField = "before"
-	afterFieldDiff  = "after"
+	afterDiffField  = "after"
 )
 
 type BaseOperatorOption Option[baseOperator]
@@ -49,7 +49,7 @@ func newBaseOperator(
 func (b *baseOperator) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 	diff[beforeDiffField] = b.resources[beforeDiffField]
-	diff[afterFieldDiff] = b.resources[afterFieldDiff]
+	diff[afterDiffField] = b.resources[afterDiffField]
 
 	return diff
 }

--- a/pkg/operator/clustermaintenancechange_v1.go
+++ b/pkg/operator/clustermaintenancechange_v1.go
@@ -185,7 +185,7 @@ func (c *ClusterMaintenanceChange) verify(ctx context.Context) error {
 	}
 
 	if c.parsedArguments.maintenance == currentState {
-		c.resources[afterFieldDiff] = currentState
+		c.resources[afterDiffField] = currentState
 		return nil
 	}
 
@@ -221,7 +221,7 @@ func (c *ClusterMaintenanceChange) operationDiff(ctx context.Context) map[string
 	diff["before"] = string(before)
 
 	afterDiffOutput := diffOutput{
-		Maintenance: c.resources[afterFieldDiff].(bool),
+		Maintenance: c.resources[afterDiffField].(bool),
 		ResourceID:  c.parsedArguments.resourceID,
 		NodeID:      c.parsedArguments.nodeID,
 	}

--- a/pkg/operator/saptuneapplysolution_v1.go
+++ b/pkg/operator/saptuneapplysolution_v1.go
@@ -173,10 +173,6 @@ func (sa *SaptuneApplySolution) rollback(ctx context.Context) error {
 	return nil
 }
 
-func (sa *SaptuneApplySolution) operationDiff(ctx context.Context) map[string]any {
-	return sa.standardDiff(ctx)
-}
-
 func isSaptuneVersionSupported(version string) bool {
 	compareOutput := semver.Compare(minimalSaptuneVersion, "v"+version)
 

--- a/pkg/operator/saptuneapplysolution_v1.go
+++ b/pkg/operator/saptuneapplysolution_v1.go
@@ -151,7 +151,7 @@ func (sa *SaptuneApplySolution) verify(ctx context.Context) error {
 	}
 
 	if alreadyApplied := isSaptuneSolutionAlreadyApplied(solutionAppliedOutput, sa.parsedArguments.solution); alreadyApplied {
-		sa.resources[afterFieldDiff] = string(solutionAppliedOutput)
+		sa.resources[afterDiffField] = string(solutionAppliedOutput)
 		return nil
 	}
 


### PR DESCRIPTION
# Description

Implement `operationDiff` on `baseOperator` so that concrete operators do not need to implement their own when not necessary.