### PR TITLE
Saptune apply refactor

### DIFF
--- a/internal/saptune/mocks/mock_Saptune.go
+++ b/internal/saptune/mocks/mock_Saptune.go
@@ -158,6 +158,49 @@ func (_c *MockSaptune_GetAppliedSolution_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
+// RevertSolution provides a mock function with given fields: ctx, solution
+func (_m *MockSaptune) RevertSolution(ctx context.Context, solution string) error {
+	ret := _m.Called(ctx, solution)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, solution)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockSaptune_RevertSolution_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RevertSolution'
+type MockSaptune_RevertSolution_Call struct {
+	*mock.Call
+}
+
+// RevertSolution is a helper method to define mock.On call
+//   - ctx context.Context
+//   - solution string
+func (_e *MockSaptune_Expecter) RevertSolution(ctx interface{}, solution interface{}) *MockSaptune_RevertSolution_Call {
+	return &MockSaptune_RevertSolution_Call{Call: _e.mock.On("RevertSolution", ctx, solution)}
+}
+
+func (_c *MockSaptune_RevertSolution_Call) Run(run func(ctx context.Context, solution string)) *MockSaptune_RevertSolution_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockSaptune_RevertSolution_Call) Return(_a0 error) *MockSaptune_RevertSolution_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSaptune_RevertSolution_Call) RunAndReturn(run func(context.Context, string) error) *MockSaptune_RevertSolution_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockSaptune creates a new instance of MockSaptune. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockSaptune(t interface {

--- a/internal/saptune/saptune.go
+++ b/internal/saptune/saptune.go
@@ -18,6 +18,7 @@ type Saptune interface {
 	CheckVersionSupport(ctx context.Context) error
 	ApplySolution(ctx context.Context, solution string) error
 	GetAppliedSolution(ctx context.Context) (string, error)
+	RevertSolution(ctx context.Context, solution string) error
 }
 
 type saptuneClient struct {
@@ -76,7 +77,25 @@ func (saptune *saptuneClient) ApplySolution(ctx context.Context, solution string
 			applyOutput,
 		)
 
-		return fmt.Errorf("could not perform saptune apply solution %s, error: %s",
+		return fmt.Errorf("could not perform saptune solution apply %s, error: %s",
+			solution,
+			err,
+		)
+	}
+
+	return nil
+}
+
+func (saptune *saptuneClient) RevertSolution(ctx context.Context, solution string) error {
+	revertOutput, err := saptune.executor.Exec(ctx, "saptune", "solution", "revert", solution)
+	if err != nil {
+		saptune.logger.Errorf(
+			"could not perform saptune solution revert %s, error output: %s",
+			solution,
+			revertOutput,
+		)
+
+		return fmt.Errorf("could not perform saptune solution revert %s, error: %s",
 			solution,
 			err,
 		)

--- a/pkg/operator/base.go
+++ b/pkg/operator/base.go
@@ -46,10 +46,6 @@ func newBaseOperator(
 	return *base
 }
 
-func (b *baseOperator) rollback(ctx context.Context) error {
-	return nil
-}
-
 func (b *baseOperator) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 	diff[beforeDiffField] = b.resources[beforeDiffField]

--- a/pkg/operator/base.go
+++ b/pkg/operator/base.go
@@ -1,8 +1,6 @@
 package operator
 
 import (
-	"context"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -44,12 +42,4 @@ func newBaseOperator(
 	base.logger = base.loggerInstance.WithField("operation_id", operationID)
 
 	return *base
-}
-
-func (b *baseOperator) operationDiff(_ context.Context) map[string]any {
-	diff := make(map[string]any)
-	diff[beforeDiffField] = b.resources[beforeDiffField]
-	diff[afterDiffField] = b.resources[afterDiffField]
-
-	return diff
 }

--- a/pkg/operator/base.go
+++ b/pkg/operator/base.go
@@ -46,6 +46,10 @@ func newBaseOperator(
 	return *base
 }
 
+func (b *baseOperator) rollback(ctx context.Context) error {
+	return nil
+}
+
 func (b *baseOperator) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 	diff[beforeDiffField] = b.resources[beforeDiffField]

--- a/pkg/operator/saptuneapplysolution_v1.go
+++ b/pkg/operator/saptuneapplysolution_v1.go
@@ -5,185 +5,32 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/tidwall/gjson"
+	"github.com/sirupsen/logrus"
+	"github.com/trento-project/workbench/internal/saptune"
 	"github.com/trento-project/workbench/internal/support"
-	"golang.org/x/mod/semver"
 )
 
-const (
-	minimalSaptuneVersion            = "v3.1.0"
-	SaptuneApplySolutionOperatorName = "saptuneapplysolution"
-)
+type saptuneOperator struct {
+	saptune saptune.Saptune
+}
 
-type SaptuneApplySolutionOption Option[SaptuneApplySolution]
-
-type saptuneApplySolutionArguments struct {
+type saptuneSolutionArguments struct {
 	solution string
 }
 
-// SaptuneApplySolution is an operator responsible for applying a saptune solution.
-//
-// The operator requires an argument in the form of a map containing a key named "solution".
-// This value will be passed to the saptune command-line tool.
-//
-// All considerations related to applying a solution using the saptune CLI apply here as well.
-//
-// # Execution Phases
-//
-// - PLAN:
-//   The operator checks for the presence of the saptune binary and verifies its version.
-//   The minimum required version is 3.1.0. If saptune is not installed or the version does not meet the minimum requirement,
-//   the operation will fail. The current state of the applied saptune solution is collected as the "before" diff.
-//
-// - COMMIT:
-//   The operator checks if the requested solution is already applied. If it is, no action is taken,
-//   ensuring idempotency without returning an error. If the solution is not applied, the saptune command
-//   to apply the solution will be executed.
-//
-// - VERIFY:
-//   The operator verifies whether the solution has been correctly applied to the system.
-//   If not, an error is raised. If successful, the current state of the applied solution is collected as the "after" diff.
-//
-// - ROLLBACK:
-//   If an error occurs during the COMMIT or VERIFY phase, the saptune revert command is executed
-//   to undo the applied solution.
-
-type SaptuneApplySolution struct {
-	baseOperator
-	executor        support.CmdExecutor
-	parsedArguments *saptuneApplySolutionArguments
-}
-
-func WithCustomSaptuneExecutor(executor support.CmdExecutor) SaptuneApplySolutionOption {
-	return func(o *SaptuneApplySolution) {
-		o.executor = executor
+func newSaptuneOperator(
+	executor support.CmdExecutor,
+	logger *logrus.Entry,
+) saptuneOperator {
+	return saptuneOperator{
+		saptune: saptune.NewSaptuneClient(
+			executor,
+			logger,
+		),
 	}
 }
 
-func NewSaptuneApplySolution(
-	arguments OperatorArguments,
-	operationID string,
-	options OperatorOptions[SaptuneApplySolution],
-) *Executor {
-	saptuneApply := &SaptuneApplySolution{
-		baseOperator: newBaseOperator(operationID, arguments, options.BaseOperatorOptions...),
-		executor:     support.CliExecutor{},
-	}
-
-	for _, opt := range options.OperatorOptions {
-		opt(saptuneApply)
-	}
-
-	return &Executor{
-		phaser:      saptuneApply,
-		operationID: operationID,
-	}
-}
-
-func (sa *SaptuneApplySolution) plan(ctx context.Context) error {
-	opArguments, err := parseSaptuneApplyArguments(sa.arguments)
-	if err != nil {
-		return err
-	}
-	sa.parsedArguments = opArguments
-
-	// check saptune version
-	versionOutput, err := sa.executor.Exec(ctx, "rpm", "-q", "--qf", "%{VERSION}", "saptune")
-	if err != nil {
-		return fmt.Errorf(
-			"could not get the installed saptune version: %w",
-			err,
-		)
-	}
-	sa.logger.Debugf("installed saptune version: %s", string(versionOutput))
-
-	if supported := isSaptuneVersionSupported(string(versionOutput)); !supported {
-		return fmt.Errorf(
-			"saptune version not supported, installed: %s, minimum supported: %s",
-			versionOutput,
-			minimalSaptuneVersion,
-		)
-	}
-
-	solutionAppliedOutput, err := sa.executor.Exec(ctx, "saptune", "--format", "json", "solution", "applied")
-	if err != nil {
-		return errors.New("could not call saptune solution applied")
-	}
-
-	sa.resources[beforeDiffField] = string(solutionAppliedOutput)
-
-	return nil
-}
-
-func (sa *SaptuneApplySolution) commit(ctx context.Context) error {
-	// check if solution is already applied
-	solutionAppliedOutput, err := sa.executor.Exec(ctx, "saptune", "--format", "json", "solution", "applied")
-	if err != nil {
-		return errors.New("could not call saptune solution applied")
-	}
-
-	if alreadyApplied := isSaptuneSolutionAlreadyApplied(solutionAppliedOutput, sa.parsedArguments.solution); alreadyApplied {
-		sa.logger.Infof("solution %s already applied, skipping saptune apply", sa.parsedArguments.solution)
-		return nil
-	}
-
-	applyOutput, err := sa.executor.Exec(ctx, "saptune", "solution", "apply", sa.parsedArguments.solution)
-	if err != nil {
-		sa.logger.Errorf(
-			"could not perform saptune solution apply %s, error output: %s",
-			sa.parsedArguments.solution,
-			applyOutput,
-		)
-
-		return fmt.Errorf("could not perform the saptune apply solution %s, error: %s",
-			sa.parsedArguments.solution,
-			err,
-		)
-	}
-
-	return nil
-}
-
-func (sa *SaptuneApplySolution) verify(ctx context.Context) error {
-	solutionAppliedOutput, err := sa.executor.Exec(ctx, "saptune", "--format", "json", "solution", "applied")
-	if err != nil {
-		return errors.New("could not call saptune solution applied")
-	}
-
-	if alreadyApplied := isSaptuneSolutionAlreadyApplied(solutionAppliedOutput, sa.parsedArguments.solution); alreadyApplied {
-		sa.resources[afterDiffField] = string(solutionAppliedOutput)
-		return nil
-	}
-
-	return fmt.Errorf(
-		"verify saptune apply failing, the solution %s was not applied in commit phase",
-		sa.parsedArguments.solution,
-	)
-}
-
-func (sa *SaptuneApplySolution) rollback(ctx context.Context) error {
-	revertOutput, err := sa.executor.Exec(ctx, "saptune", "solution", "revert", sa.parsedArguments.solution)
-	if err != nil {
-		return fmt.Errorf("could not revert saptune solution %s during rollback, error: %s",
-			sa.parsedArguments.solution,
-			revertOutput,
-		)
-	}
-
-	return nil
-}
-
-func isSaptuneVersionSupported(version string) bool {
-	compareOutput := semver.Compare(minimalSaptuneVersion, "v"+version)
-
-	return compareOutput != 1
-}
-
-func isSaptuneSolutionAlreadyApplied(saptuneOutput []byte, solution string) bool {
-	return gjson.GetBytes(saptuneOutput, fmt.Sprintf(`result.Solution applied.#(Solution ID=="%s")`, solution)).Exists()
-}
-
-func parseSaptuneApplyArguments(rawArguments OperatorArguments) (*saptuneApplySolutionArguments, error) {
+func parseSaptuneSolutionArguments(rawArguments OperatorArguments) (*saptuneSolutionArguments, error) {
 	argument, found := rawArguments["solution"]
 	if !found {
 		return nil, errors.New("argument solution not provided, could not use the operator")
@@ -197,7 +44,135 @@ func parseSaptuneApplyArguments(rawArguments OperatorArguments) (*saptuneApplySo
 		)
 	}
 
-	return &saptuneApplySolutionArguments{
+	return &saptuneSolutionArguments{
 		solution: solution,
 	}, nil
+}
+
+const SaptuneApplySolutionOperatorName = "saptuneapplysolution"
+
+type SaptuneApplySolutionOption Option[SaptuneApplySolution]
+
+// SaptuneApplySolution is an operator responsible for applying a saptune solution.
+//
+// The operator requires an argument in the form of a map containing a key named "solution".
+// This value will be passed to the saptune command-line tool.
+//
+// All considerations related to applying a solution using the saptune CLI apply here as well.
+//
+// # Execution Phases
+//
+// - PLAN:
+//   The operator checks for the presence of the saptune binary and verifies its version.
+//   The minimum required version is 3.1.0. If saptune is not installed or the version does not meet the minimum requirement,
+//   the operation will fail.
+//   The initially applied solution, if any, is collected as the "before" diff.
+//
+// - COMMIT:
+//   The operator checks if the requested solution is already applied. If it is, no action is taken,
+//   ensuring idempotency without returning an error.
+//   If there is any other solution already applied, an error is raised, because only one solution can be applied at a time.
+// 	 If otherwise there is no solution applied the saptune command to apply the solution will be executed.
+//
+// - VERIFY:
+//   The operator verifies whether the solution has been correctly applied to the system.
+//   If not, an error is raised. If successful, the current state of the applied solution is collected as the "after" diff.
+//
+// - ROLLBACK:
+//   There is nothing to rollback in this operator.
+//   If the COMMIT phase fails before attempting to apply the solution, it would not make sense to revert a not applied solution.
+//   If the COMMIT phase fails when applying the solution, again it would not make sense to revert a solution that was not applied.
+//   If the VERIFY phase fails when retrieving the applied solution, it might be risky to revert the solution that possibly should be applied.
+//   If the VERIFY phase fails when because the solution requested to be applied is not the resulting applied one, it might still be risky to revert the solution that possibly should be applied.
+
+type SaptuneApplySolution struct {
+	baseOperator
+	saptuneOperator
+	parsedArguments *saptuneSolutionArguments
+}
+
+func WithSaptuneClient(saptuneClient saptune.Saptune) SaptuneApplySolutionOption {
+	return func(o *SaptuneApplySolution) {
+		o.saptuneOperator.saptune = saptuneClient
+	}
+}
+
+func NewSaptuneApplySolution(
+	arguments OperatorArguments,
+	operationID string,
+	options OperatorOptions[SaptuneApplySolution],
+) *Executor {
+	saptuneApply := &SaptuneApplySolution{
+		baseOperator: newBaseOperator(operationID, arguments, options.BaseOperatorOptions...),
+	}
+
+	saptuneApply.saptuneOperator = newSaptuneOperator(
+		support.CliExecutor{},
+		saptuneApply.logger,
+	)
+
+	for _, opt := range options.OperatorOptions {
+		opt(saptuneApply)
+	}
+
+	return &Executor{
+		phaser:      saptuneApply,
+		operationID: operationID,
+	}
+}
+
+func (sa *SaptuneApplySolution) plan(ctx context.Context) error {
+	opArguments, err := parseSaptuneSolutionArguments(sa.arguments)
+	if err != nil {
+		return err
+	}
+	sa.parsedArguments = opArguments
+
+	if err = sa.saptune.CheckVersionSupport(ctx); err != nil {
+		return err
+	}
+
+	initiallyAppliedSolution, err := sa.saptune.GetAppliedSolution(ctx)
+	if err != nil {
+		return err
+	}
+
+	sa.resources[beforeDiffField] = initiallyAppliedSolution
+
+	return nil
+}
+
+func (sa *SaptuneApplySolution) commit(ctx context.Context) error {
+	initiallyAppliedSolution := sa.resources[beforeDiffField].(string)
+
+	if sa.parsedArguments.solution == initiallyAppliedSolution {
+		sa.logger.Infof("solution %s is already applied, skipping commit phase", sa.parsedArguments.solution)
+		return nil
+	}
+
+	if initiallyAppliedSolution != "" {
+		return fmt.Errorf(
+			"cannot apply solution %s because another solution %s is already applied",
+			sa.parsedArguments.solution,
+			initiallyAppliedSolution,
+		)
+	}
+
+	return sa.saptune.ApplySolution(ctx, sa.parsedArguments.solution)
+}
+
+func (sa *SaptuneApplySolution) verify(ctx context.Context) error {
+	appliedSolution, err := sa.saptune.GetAppliedSolution(ctx)
+	if err != nil {
+		return err
+	}
+
+	if appliedSolution != sa.parsedArguments.solution {
+		return fmt.Errorf(
+			"verify saptune apply failing, the solution %s was not applied in commit phase",
+			sa.parsedArguments.solution,
+		)
+	}
+	sa.resources[afterDiffField] = appliedSolution
+	return nil
 }

--- a/pkg/operator/saptuneapplysolution_v1.go
+++ b/pkg/operator/saptuneapplysolution_v1.go
@@ -143,7 +143,10 @@ func (sa *SaptuneApplySolution) plan(ctx context.Context) error {
 }
 
 func (sa *SaptuneApplySolution) commit(ctx context.Context) error {
-	initiallyAppliedSolution := sa.resources[beforeDiffField].(string)
+	initiallyAppliedSolution, ok := sa.resources[beforeDiffField].(string)
+	if !ok {
+		return fmt.Errorf("expected a string for initiallyAppliedSolution, but got %T", sa.resources[beforeDiffField])
+	}
 
 	if sa.parsedArguments.solution == initiallyAppliedSolution {
 		sa.logger.Infof("solution %s is already applied, skipping commit phase", sa.parsedArguments.solution)

--- a/pkg/operator/saptuneapplysolution_v1.go
+++ b/pkg/operator/saptuneapplysolution_v1.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -69,6 +70,10 @@ type SaptuneApplySolution struct {
 	baseOperator
 	saptune         saptune.Saptune
 	parsedArguments *saptuneSolutionArguments
+}
+
+type saptuneOperationDiffOutput struct {
+	Solution string `json:"solution"`
 }
 
 func WithSaptuneClient(saptuneClient saptune.Saptune) SaptuneApplySolutionOption {
@@ -165,4 +170,22 @@ func (sa *SaptuneApplySolution) rollback(ctx context.Context) error {
 	}
 
 	return sa.saptune.RevertSolution(ctx, sa.parsedArguments.solution)
+}
+
+func (sa *SaptuneApplySolution) operationDiff(_ context.Context) map[string]any {
+	diff := make(map[string]any)
+
+	beforeDiffOutput := saptuneOperationDiffOutput{
+		Solution: sa.resources[beforeDiffField].(string),
+	}
+	before, _ := json.Marshal(beforeDiffOutput)
+	diff[beforeDiffField] = string(before)
+
+	afterDiffOutput := saptuneOperationDiffOutput{
+		Solution: sa.resources[afterDiffField].(string),
+	}
+	after, _ := json.Marshal(afterDiffOutput)
+	diff[afterDiffField] = string(after)
+
+	return diff
 }

--- a/pkg/operator/saptuneapplysolution_v1.go
+++ b/pkg/operator/saptuneapplysolution_v1.go
@@ -123,10 +123,7 @@ func (sa *SaptuneApplySolution) plan(ctx context.Context) error {
 }
 
 func (sa *SaptuneApplySolution) commit(ctx context.Context) error {
-	initiallyAppliedSolution, ok := sa.resources[beforeDiffField].(string)
-	if !ok {
-		return fmt.Errorf("expected a string for initiallyAppliedSolution, but got %T", sa.resources[beforeDiffField])
-	}
+	initiallyAppliedSolution, _ := sa.resources[beforeDiffField].(string)
 
 	if sa.parsedArguments.solution == initiallyAppliedSolution {
 		sa.logger.Infof("solution %s is already applied, skipping commit phase", sa.parsedArguments.solution)
@@ -161,5 +158,11 @@ func (sa *SaptuneApplySolution) verify(ctx context.Context) error {
 }
 
 func (sa *SaptuneApplySolution) rollback(ctx context.Context) error {
+	initiallyAppliedSolution, _ := sa.resources[beforeDiffField].(string)
+
+	if initiallyAppliedSolution != "" {
+		return nil
+	}
+
 	return sa.saptune.RevertSolution(ctx, sa.parsedArguments.solution)
 }

--- a/pkg/operator/saptuneapplysolution_v1.go
+++ b/pkg/operator/saptuneapplysolution_v1.go
@@ -62,11 +62,8 @@ type SaptuneApplySolutionOption Option[SaptuneApplySolution]
 //   If not, an error is raised. If successful, the current state of the applied solution is collected as the "after" diff.
 //
 // - ROLLBACK:
-//   There is nothing to rollback in this operator.
-//   If the COMMIT phase fails before attempting to apply the solution, it would not make sense to revert a not applied solution.
-//   If the COMMIT phase fails when applying the solution, again it would not make sense to revert a solution that was not applied.
-//   If the VERIFY phase fails when retrieving the applied solution, it might be risky to revert the solution that possibly should be applied.
-//   If the VERIFY phase fails when because the solution requested to be applied is not the resulting applied one, it might still be risky to revert the solution that possibly should be applied.
+//   If an error occurs during the COMMIT or VERIFY phase, the saptune revert command is executed
+//   to undo the applied solution.
 
 type SaptuneApplySolution struct {
 	baseOperator
@@ -163,6 +160,6 @@ func (sa *SaptuneApplySolution) verify(ctx context.Context) error {
 	return nil
 }
 
-func (b *baseOperator) rollback(ctx context.Context) error {
-	return nil
+func (sa *SaptuneApplySolution) rollback(ctx context.Context) error {
+	return sa.saptune.RevertSolution(ctx, sa.parsedArguments.solution)
 }

--- a/pkg/operator/saptuneapplysolution_v1_test.go
+++ b/pkg/operator/saptuneapplysolution_v1_test.go
@@ -544,8 +544,8 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionSucc
 	report := saptuneSolutionApplyOperator.Run(ctx)
 
 	expectedDiff := map[string]any{
-		"before": "",
-		"after":  "HANA",
+		"before": `{"solution":""}`,
+		"after":  `{"solution":"HANA"}`,
 	}
 
 	suite.Nil(report.Error)
@@ -584,8 +584,8 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionSucc
 	report := saptuneSolutionApplyOperator.Run(ctx)
 
 	expectedDiff := map[string]any{
-		"before": "HANA",
-		"after":  "HANA",
+		"before": `{"solution":"HANA"}`,
+		"after":  `{"solution":"HANA"}`,
 	}
 
 	suite.Nil(report.Error)

--- a/pkg/operator/saptuneapplysolution_v1_test.go
+++ b/pkg/operator/saptuneapplysolution_v1_test.go
@@ -23,7 +23,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) SetupTest() {
 	suite.mockSaptuneClient = mocks.NewMockSaptune(suite.T())
 }
 
-func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlanErrorBecauseFailingToParseArguments() {
+func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlanErrorParsingArguments() {
 	ctx := context.Background()
 
 	saptuneSolutionApplyOperator := operator.NewSaptuneApplySolution(
@@ -41,7 +41,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlan
 	suite.EqualValues("argument solution not provided, could not use the operator", report.Error.Message)
 }
 
-func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlanErrorBecauseFailingVersionCheck() {
+func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlanErrorVersionCheck() {
 	ctx := context.Background()
 
 	suite.mockSaptuneClient.On(
@@ -69,7 +69,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlan
 	suite.EqualValues("saptune version not supported", report.Error.Message)
 }
 
-func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlanErrorBecauseFailingToDetermineInitiallyAppliedSolution() {
+func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlanErrorGettingSolution() {
 	ctx := context.Background()
 
 	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
@@ -104,7 +104,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlan
 	suite.EqualValues("failed to determine initially applied solution", report.Error.Message)
 }
 
-func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionCommitFailingBecauseAnotherSolutionIsAlreadyAppliedWithSuccessfulRollback() {
+func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionCommitErrorAnotherSolutionAlreadyAppliedWithSuccessfulRollback() {
 	ctx := context.Background()
 
 	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
@@ -148,7 +148,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionComm
 	suite.EqualValues("cannot apply solution S4HANA-DBSERVER because another solution HANA is already applied", report.Error.Message)
 }
 
-func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionCommitFailingBecauseAnotherSolutionIsAlreadyAppliedWithFailingRollback() {
+func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionCommitErrorAnotherSolutionAlreadyAppliedWithFailingRollback() {
 	ctx := context.Background()
 
 	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
@@ -193,7 +193,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionComm
 	suite.Contains(report.Error.Message, "cannot apply solution S4HANA-DBSERVER because another solution HANA is already applied")
 }
 
-func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionCommitFailingBecauseApplyErrorWithSuccessfulRollback() {
+func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionCommitErrorApplyingSolutionWithSuccessfulRollback() {
 	ctx := context.Background()
 
 	checkVersionSupportCall := suite.mockSaptuneClient.On(
@@ -247,7 +247,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionComm
 	suite.EqualValues("failed to apply solution", report.Error.Message)
 }
 
-func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionCommitFailingBecauseApplyErrorWithFailingRollback() {
+func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionCommitErrorApplyingSolutionWithFailingRollback() {
 	ctx := context.Background()
 
 	checkVersionSupportCall := suite.mockSaptuneClient.On(
@@ -302,7 +302,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionComm
 	suite.Contains(report.Error.Message, "failed to revert solution")
 }
 
-func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVerifyFailingBecauseUnableToDetermineAppliedSolutionWithSuccessfulRollback() {
+func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVerifyErrorDeterminingAppliedSolutionWithSuccessfulRollback() {
 	ctx := context.Background()
 
 	checkVersionSupportCall := suite.mockSaptuneClient.On(
@@ -362,7 +362,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVeri
 	suite.EqualValues("failed to determine applied solution during verify", report.Error.Message)
 }
 
-func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVerifyFailingBecauseUnableToDetermineAppliedSolutionWithFailingRollback() {
+func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVerifyErrorDeterminingAppliedSolutionWithFailingRollback() {
 	ctx := context.Background()
 
 	checkVersionSupportCall := suite.mockSaptuneClient.On(
@@ -423,7 +423,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVeri
 	suite.Contains(report.Error.Message, "failed to revert solution")
 }
 
-func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVerifyFailingBecauseDetectedAppliedSolutionDiffersFromRequestedWithSuccessfulRollback() {
+func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVerifyErrorAppliedSolutionDiffersFromRequestedWithSuccessfulRollback() {
 	ctx := context.Background()
 
 	checkVersionSupportCall := suite.mockSaptuneClient.On(
@@ -487,7 +487,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVeri
 	suite.EqualValues("verify saptune apply failing, the solution HANA was not applied in commit phase", report.Error.Message)
 }
 
-func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVerifyFailingBecauseDetectedAppliedSolutionDiffersFromRequestedWithFailingRollback() {
+func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionErrorDetectedAppliedSolutionDiffersFromRequestedWithFailingRollback() {
 	ctx := context.Background()
 
 	checkVersionSupportCall := suite.mockSaptuneClient.On(

--- a/test/fixtures/saptune/revert_not_applied_solution.output
+++ b/test/fixtures/saptune/revert_not_applied_solution.output
@@ -1,0 +1,17 @@
+
+WARNING: Perf Bias settings not supported by the system
+WARNING: Governor settings not supported by the system
+Parameters tuned by the notes referred by the SAP solution have been successfully reverted.
+fab-vmhana01:~ # saptune solution revert HANA
+
+WARNING: noteID '941735' not found in configuration 'NoteApplyOrder'
+WARNING: noteID '1771258' not found in configuration 'NoteApplyOrder'
+WARNING: noteID '1868829' not found in configuration 'NoteApplyOrder'
+WARNING: noteID '1980196' not found in configuration 'NoteApplyOrder'
+WARNING: noteID '2578899' not found in configuration 'NoteApplyOrder'
+WARNING: noteID '2684254' not found in configuration 'NoteApplyOrder'
+WARNING: noteID '2382421' not found in configuration 'NoteApplyOrder'
+WARNING: noteID '2534844' not found in configuration 'NoteApplyOrder'
+WARNING: noteID '2993054' not found in configuration 'NoteApplyOrder'
+WARNING: noteID '1656250' not found in configuration 'NoteApplyOrder'
+NOTICE: Solution 'HANA' is not applied, so nothing to revert.

--- a/test/fixtures/saptune/revert_solution_success.output
+++ b/test/fixtures/saptune/revert_solution_success.output
@@ -1,0 +1,4 @@
+
+WARNING: Perf Bias settings not supported by the system
+WARNING: Governor settings not supported by the system
+Parameters tuned by the notes referred by the SAP solution have been successfully reverted.


### PR DESCRIPTION
# Description

This PR refactors current saptune apply operator to leverage saptune abstraction introduced in https://github.com/trento-project/workbench/pull/15

During the exploration I realized that the current saptune apply operator might need some improvements.

Notably:
- an apply operation is possible only if there is no other solutions
- we might want to be careful in reverting a solution during this operation

The proposed solution might not be the optimal one, open for feedback.