### PR TITLE
Saptune solution change operator

### DIFF
--- a/internal/saptune/mocks/mock_Saptune.go
+++ b/internal/saptune/mocks/mock_Saptune.go
@@ -64,6 +64,49 @@ func (_c *MockSaptune_ApplySolution_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
+// ChangeSolution provides a mock function with given fields: ctx, solution
+func (_m *MockSaptune) ChangeSolution(ctx context.Context, solution string) error {
+	ret := _m.Called(ctx, solution)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, solution)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockSaptune_ChangeSolution_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChangeSolution'
+type MockSaptune_ChangeSolution_Call struct {
+	*mock.Call
+}
+
+// ChangeSolution is a helper method to define mock.On call
+//   - ctx context.Context
+//   - solution string
+func (_e *MockSaptune_Expecter) ChangeSolution(ctx interface{}, solution interface{}) *MockSaptune_ChangeSolution_Call {
+	return &MockSaptune_ChangeSolution_Call{Call: _e.mock.On("ChangeSolution", ctx, solution)}
+}
+
+func (_c *MockSaptune_ChangeSolution_Call) Run(run func(ctx context.Context, solution string)) *MockSaptune_ChangeSolution_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockSaptune_ChangeSolution_Call) Return(_a0 error) *MockSaptune_ChangeSolution_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSaptune_ChangeSolution_Call) RunAndReturn(run func(context.Context, string) error) *MockSaptune_ChangeSolution_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CheckVersionSupport provides a mock function with given fields: ctx
 func (_m *MockSaptune) CheckVersionSupport(ctx context.Context) error {
 	ret := _m.Called(ctx)

--- a/internal/saptune/saptune.go
+++ b/internal/saptune/saptune.go
@@ -16,8 +16,9 @@ const minimalSaptuneVersion = "v3.1.0"
 
 type Saptune interface {
 	CheckVersionSupport(ctx context.Context) error
-	ApplySolution(ctx context.Context, solution string) error
 	GetAppliedSolution(ctx context.Context) (string, error)
+	ApplySolution(ctx context.Context, solution string) error
+	ChangeSolution(ctx context.Context, solution string) error
 	RevertSolution(ctx context.Context, solution string) error
 }
 
@@ -78,6 +79,24 @@ func (saptune *saptuneClient) ApplySolution(ctx context.Context, solution string
 		)
 
 		return fmt.Errorf("could not perform saptune solution apply %s, error: %s",
+			solution,
+			err,
+		)
+	}
+
+	return nil
+}
+
+func (saptune *saptuneClient) ChangeSolution(ctx context.Context, solution string) error {
+	changeSolutionOutput, err := saptune.executor.Exec(ctx, "saptune", "solution", "change", "--force", solution)
+	if err != nil {
+		saptune.logger.Errorf(
+			"could not perform saptune solution change %s, error output: %s",
+			solution,
+			changeSolutionOutput,
+		)
+
+		return fmt.Errorf("could not perform saptune change solution %s, error: %s",
 			solution,
 			err,
 		)

--- a/pkg/operator/registry.go
+++ b/pkg/operator/registry.go
@@ -113,6 +113,13 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 					})
 				},
 			},
+			SaptuneChangeSolutionOperatorName: map[string]OperatorBuilder{
+				"v1": func(operationID string, arguments OperatorArguments) Operator {
+					return NewSaptuneChangeSolution(arguments, operationID, OperatorOptions[SaptuneChangeSolution]{
+						BaseOperatorOptions: options,
+					})
+				},
+			},
 		},
 	}
 }

--- a/pkg/operator/saptuneapplysolution_v1.go
+++ b/pkg/operator/saptuneapplysolution_v1.go
@@ -39,11 +39,7 @@ func parseSaptuneSolutionArguments(rawArguments OperatorArguments) (*saptuneSolu
 
 const SaptuneApplySolutionOperatorName = "saptuneapplysolution"
 
-type SaptuneOperator interface {
-	SaptuneApplySolution | SaptuneChangeSolution
-}
-
-type SaptuneOperatorOption[T SaptuneOperator] Option[T]
+type SaptuneApplySolutionOption Option[SaptuneApplySolution]
 
 // SaptuneApplySolution is an operator responsible for applying a saptune solution.
 //
@@ -84,16 +80,9 @@ type saptuneOperationDiffOutput struct {
 	Solution string `json:"solution"`
 }
 
-func WithSaptuneClient[T SaptuneOperator](saptuneClient saptune.Saptune) Option[T] {
-	return func(o *T) {
-		switch op := any(o).(type) {
-		case *SaptuneApplySolution:
-			op.saptune = saptuneClient
-		case *SaptuneChangeSolution:
-			op.saptune = saptuneClient
-		default:
-			panic(fmt.Sprintf("unsupported operator type: %T", op))
-		}
+func WithSaptuneClientApply(saptuneClient saptune.Saptune) SaptuneApplySolutionOption {
+	return func(o *SaptuneApplySolution) {
+		o.saptune = saptuneClient
 	}
 }
 

--- a/pkg/operator/saptuneapplysolution_v1.go
+++ b/pkg/operator/saptuneapplysolution_v1.go
@@ -28,6 +28,10 @@ func parseSaptuneSolutionArguments(rawArguments OperatorArguments) (*saptuneSolu
 		)
 	}
 
+	if solution == "" {
+		return nil, errors.New("solution argument is empty")
+	}
+
 	return &saptuneSolutionArguments{
 		solution: solution,
 	}, nil

--- a/pkg/operator/saptuneapplysolution_v1_test.go
+++ b/pkg/operator/saptuneapplysolution_v1_test.go
@@ -75,7 +75,9 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlan
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClient(suite.mockSaptuneClient)),
+				operator.Option[operator.SaptuneApplySolution](
+					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
+				),
 			},
 		},
 	)
@@ -110,7 +112,9 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlan
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClient(suite.mockSaptuneClient)),
+				operator.Option[operator.SaptuneApplySolution](
+					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
+				),
 			},
 		},
 	)
@@ -145,7 +149,9 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionComm
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClient(suite.mockSaptuneClient)),
+				operator.Option[operator.SaptuneApplySolution](
+					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
+				),
 			},
 		},
 	)
@@ -199,7 +205,9 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionComm
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClient(suite.mockSaptuneClient)),
+				operator.Option[operator.SaptuneApplySolution](
+					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
+				),
 			},
 		},
 	)
@@ -253,7 +261,9 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionComm
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClient(suite.mockSaptuneClient)),
+				operator.Option[operator.SaptuneApplySolution](
+					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
+				),
 			},
 		},
 	)
@@ -314,7 +324,9 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVeri
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClient(suite.mockSaptuneClient)),
+				operator.Option[operator.SaptuneApplySolution](
+					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
+				),
 			},
 		},
 	)
@@ -374,7 +386,9 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVeri
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClient(suite.mockSaptuneClient)),
+				operator.Option[operator.SaptuneApplySolution](
+					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
+				),
 			},
 		},
 	)
@@ -439,7 +453,9 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVeri
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClient(suite.mockSaptuneClient)),
+				operator.Option[operator.SaptuneApplySolution](
+					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
+				),
 			},
 		},
 	)
@@ -503,7 +519,9 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionErro
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClient(suite.mockSaptuneClient)),
+				operator.Option[operator.SaptuneApplySolution](
+					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
+				),
 			},
 		},
 	)
@@ -554,7 +572,9 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionSucc
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClient(suite.mockSaptuneClient)),
+				operator.Option[operator.SaptuneApplySolution](
+					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
+				),
 			},
 		},
 	)
@@ -594,7 +614,9 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionSucc
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClient(suite.mockSaptuneClient)),
+				operator.Option[operator.SaptuneApplySolution](
+					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
+				),
 			},
 		},
 	)

--- a/pkg/operator/saptuneapplysolution_v1_test.go
+++ b/pkg/operator/saptuneapplysolution_v1_test.go
@@ -75,9 +75,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlan
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](
-					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -112,9 +110,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlan
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](
-					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -149,9 +145,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionComm
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](
-					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -205,9 +199,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionComm
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](
-					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -261,9 +253,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionComm
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](
-					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -324,9 +314,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVeri
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](
-					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -386,9 +374,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVeri
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](
-					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -453,9 +439,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVeri
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](
-					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -519,9 +503,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionErro
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](
-					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -572,9 +554,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionSucc
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](
-					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -614,9 +594,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionSucc
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
-				operator.Option[operator.SaptuneApplySolution](
-					operator.WithSaptuneClient[operator.SaptuneApplySolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
 		},
 	)

--- a/pkg/operator/saptuneapplysolution_v1_test.go
+++ b/pkg/operator/saptuneapplysolution_v1_test.go
@@ -41,6 +41,24 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlan
 	suite.EqualValues("argument solution not provided, could not use the operator", report.Error.Message)
 }
 
+func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlanErrorEmptySolutionRequested() {
+	ctx := context.Background()
+
+	saptuneSolutionApplyOperator := operator.NewSaptuneApplySolution(
+		operator.OperatorArguments{
+			"solution": "",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneApplySolution]{},
+	)
+
+	report := saptuneSolutionApplyOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("solution argument is empty", report.Error.Message)
+}
+
 func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlanErrorVersionCheck() {
 	ctx := context.Background()
 

--- a/pkg/operator/saptunechangesolution_v1.go
+++ b/pkg/operator/saptunechangesolution_v1.go
@@ -33,7 +33,7 @@ type SaptuneChangeSolutionOption Option[SaptuneChangeSolution]
 //   On success, the current state of the applied solution is collected as the "after" diff.
 //
 // - ROLLBACK:
-//   TBD
+//   If an error occurs during the COMMIT or VERIFY phase, the saptune solution is changed back to the initially applied one.
 
 type SaptuneChangeSolution struct {
 	baseOperator
@@ -138,11 +138,6 @@ func (sc *SaptuneChangeSolution) rollback(ctx context.Context) error {
 
 	if initiallyAppliedSolution == "" {
 		return nil
-	}
-
-	sc.logger.Infof("Reverting the requested solution: %s", sc.parsedArguments.solution)
-	if err := sc.saptune.RevertSolution(ctx, sc.parsedArguments.solution); err != nil {
-		return err
 	}
 
 	sc.logger.Infof("Changing solution to the initially applied one: %s", initiallyAppliedSolution)

--- a/pkg/operator/saptunechangesolution_v1.go
+++ b/pkg/operator/saptunechangesolution_v1.go
@@ -1,0 +1,9 @@
+package operator
+
+import "github.com/trento-project/workbench/internal/saptune"
+
+type SaptuneChangeSolution struct {
+	baseOperator
+	saptune         saptune.Saptune
+	parsedArguments *saptuneSolutionArguments
+}

--- a/pkg/operator/saptunechangesolution_v1.go
+++ b/pkg/operator/saptunechangesolution_v1.go
@@ -11,6 +11,8 @@ import (
 
 const SaptuneChangeSolutionOperatorName = "saptunechangesolution"
 
+type SaptuneChangeSolutionOption Option[SaptuneChangeSolution]
+
 // SaptuneChangeSolution is an operator responsible for changing a saptune solution.
 //
 // It requires the same kind of argument needed for SaptuneApplySolution: a map containing a key named "solution".
@@ -37,6 +39,12 @@ type SaptuneChangeSolution struct {
 	baseOperator
 	saptune         saptune.Saptune
 	parsedArguments *saptuneSolutionArguments
+}
+
+func WithSaptuneClientChange(saptuneClient saptune.Saptune) SaptuneChangeSolutionOption {
+	return func(o *SaptuneChangeSolution) {
+		o.saptune = saptuneClient
+	}
 }
 
 func NewSaptuneChangeSolution(

--- a/pkg/operator/saptunechangesolution_v1.go
+++ b/pkg/operator/saptunechangesolution_v1.go
@@ -1,9 +1,160 @@
 package operator
 
-import "github.com/trento-project/workbench/internal/saptune"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/trento-project/workbench/internal/saptune"
+	"github.com/trento-project/workbench/internal/support"
+)
+
+const SaptuneChangeSolutionOperatorName = "saptunechangesolution"
+
+// SaptuneChangeSolution is an operator responsible for changing a saptune solution.
+//
+// It requires the same kind of argument needed for SaptuneApplySolution: a map containing a key named "solution".
+//
+// # Execution Phases
+//
+// - PLAN:
+//   Same as SaptuneApplySolutionOption.
+//
+// - COMMIT:
+//   The operator checks if the requested solution is already applied. If it is, no action is taken, ensuring idempotency.
+//   If there is no other solution already applied, an error is raised,
+//   effectively allowing a transition from a solution to another but not from no solution to some solution.
+// 	 If otherwise there is a solution applied that is not the currently applied one the saptune command to change the solution will be executed.
+//
+// - VERIFY:
+//   The operator verifies whether the solution has been correctly changed to the requested one. If not, an error is raised.
+//   On success, the current state of the applied solution is collected as the "after" diff.
+//
+// - ROLLBACK:
+//   TBD
 
 type SaptuneChangeSolution struct {
 	baseOperator
 	saptune         saptune.Saptune
 	parsedArguments *saptuneSolutionArguments
+}
+
+func NewSaptuneChangeSolution(
+	arguments OperatorArguments,
+	operationID string,
+	options OperatorOptions[SaptuneChangeSolution],
+) *Executor {
+	saptuneChange := &SaptuneChangeSolution{
+		baseOperator: newBaseOperator(operationID, arguments, options.BaseOperatorOptions...),
+	}
+
+	saptuneChange.saptune = saptune.NewSaptuneClient(
+		support.CliExecutor{},
+		saptuneChange.logger,
+	)
+
+	for _, opt := range options.OperatorOptions {
+		opt(saptuneChange)
+	}
+
+	return &Executor{
+		phaser:      saptuneChange,
+		operationID: operationID,
+	}
+}
+
+func (sc *SaptuneChangeSolution) plan(ctx context.Context) error {
+	opArguments, err := parseSaptuneSolutionArguments(sc.arguments)
+	if err != nil {
+		return err
+	}
+	sc.parsedArguments = opArguments
+
+	if err = sc.saptune.CheckVersionSupport(ctx); err != nil {
+		return err
+	}
+
+	initiallyAppliedSolution, err := sc.saptune.GetAppliedSolution(ctx)
+	if err != nil {
+		return err
+	}
+
+	sc.resources[beforeDiffField] = initiallyAppliedSolution
+
+	return nil
+}
+
+func (sc *SaptuneChangeSolution) commit(ctx context.Context) error {
+	initiallyAppliedSolution, _ := sc.resources[beforeDiffField].(string)
+
+	if initiallyAppliedSolution == "" {
+		return fmt.Errorf(
+			"cannot change solution to %s because no solution is currently applied",
+			sc.parsedArguments.solution,
+		)
+	}
+
+	if sc.parsedArguments.solution == initiallyAppliedSolution {
+		sc.logger.Infof("solution %s is already applied. Nothing to change, skipping commit phase", sc.parsedArguments.solution)
+		return nil
+	}
+
+	return sc.saptune.ChangeSolution(ctx, sc.parsedArguments.solution)
+}
+
+func (sc *SaptuneChangeSolution) verify(ctx context.Context) error {
+	initiallyAppliedSolution, _ := sc.resources[beforeDiffField].(string)
+
+	if sc.parsedArguments.solution == initiallyAppliedSolution {
+		sc.resources[afterDiffField] = initiallyAppliedSolution
+		return nil
+	}
+
+	appliedSolution, err := sc.saptune.GetAppliedSolution(ctx)
+	if err != nil {
+		return err
+	}
+
+	if appliedSolution != sc.parsedArguments.solution {
+		return fmt.Errorf(
+			"verify saptune apply failing, the solution %s was not applied in commit phase",
+			sc.parsedArguments.solution,
+		)
+	}
+	sc.resources[afterDiffField] = appliedSolution
+	return nil
+}
+
+func (sc *SaptuneChangeSolution) rollback(ctx context.Context) error {
+	initiallyAppliedSolution, _ := sc.resources[beforeDiffField].(string)
+
+	if initiallyAppliedSolution == "" {
+		return nil
+	}
+
+	sc.logger.Infof("Reverting the requested solution: %s", sc.parsedArguments.solution)
+	if err := sc.saptune.RevertSolution(ctx, sc.parsedArguments.solution); err != nil {
+		return err
+	}
+
+	sc.logger.Infof("Changing solution to the initially applied one: %s", initiallyAppliedSolution)
+	return sc.saptune.ChangeSolution(ctx, initiallyAppliedSolution)
+}
+
+func (sa *SaptuneChangeSolution) operationDiff(_ context.Context) map[string]any {
+	diff := make(map[string]any)
+
+	beforeDiffOutput := saptuneOperationDiffOutput{
+		Solution: sa.resources[beforeDiffField].(string),
+	}
+	before, _ := json.Marshal(beforeDiffOutput)
+	diff[beforeDiffField] = string(before)
+
+	afterDiffOutput := saptuneOperationDiffOutput{
+		Solution: sa.resources[afterDiffField].(string),
+	}
+	after, _ := json.Marshal(afterDiffOutput)
+	diff[afterDiffField] = string(after)
+
+	return diff
 }

--- a/pkg/operator/saptunechangesolution_v1_test.go
+++ b/pkg/operator/saptunechangesolution_v1_test.go
@@ -183,16 +183,6 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCo
 		NotBefore(getAppliedSolutionCall).
 		Once()
 
-	revertSolutionCall := suite.mockSaptuneClient.On(
-		"RevertSolution",
-		ctx,
-		"HANA",
-	).Return(nil).
-		NotBefore(checkSaptuneVersionCall).
-		NotBefore(getAppliedSolutionCall).
-		NotBefore(changeSolutionCall).
-		Once()
-
 	suite.mockSaptuneClient.On(
 		"ChangeSolution",
 		ctx,
@@ -201,7 +191,6 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCo
 		NotBefore(checkSaptuneVersionCall).
 		NotBefore(getAppliedSolutionCall).
 		NotBefore(changeSolutionCall).
-		NotBefore(revertSolutionCall).
 		Once()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
@@ -222,7 +211,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCo
 
 }
 
-func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCommitErrorChangeSolutionFailingRollbackRevert() {
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCommitErrorChangeSolutionFailingRollback() {
 	ctx := context.Background()
 
 	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
@@ -245,69 +234,6 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCo
 	).Return(errors.New("failed to change solution")).
 		NotBefore(checkSaptuneVersionCall).
 		NotBefore(getAppliedSolutionCall).
-		Once()
-
-	suite.mockSaptuneClient.On(
-		"RevertSolution",
-		ctx,
-		"HANA",
-	).Return(errors.New("failed to revert solution")).
-		NotBefore(checkSaptuneVersionCall).
-		NotBefore(getAppliedSolutionCall).
-		NotBefore(changeSolutionCall).
-		Once()
-
-	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
-		operator.OperatorArguments{
-			"solution": "HANA",
-		},
-		"test-op",
-		operator.OperatorOptions[operator.SaptuneChangeSolution]{
-			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
-			},
-		},
-	)
-	report := saptuneSolutionChangeOperator.Run(ctx)
-	suite.Nil(report.Success)
-	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
-	suite.Contains(report.Error.Message, "failed to change solution")
-	suite.Contains(report.Error.Message, "failed to revert solution")
-}
-
-func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCommitErrorChangeSolutionFailingRollbackChange() {
-	ctx := context.Background()
-
-	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
-		"CheckVersionSupport",
-		ctx,
-	).Return(nil).
-		Once()
-
-	getAppliedSolutionCall := suite.mockSaptuneClient.On(
-		"GetAppliedSolution",
-		ctx,
-	).Return("FOO", nil).
-		NotBefore(checkSaptuneVersionCall).
-		Once()
-
-	changeSolutionCall := suite.mockSaptuneClient.On(
-		"ChangeSolution",
-		ctx,
-		"HANA",
-	).Return(errors.New("failed to change solution")).
-		NotBefore(checkSaptuneVersionCall).
-		NotBefore(getAppliedSolutionCall).
-		Once()
-
-	revertSolutionCall := suite.mockSaptuneClient.On(
-		"RevertSolution",
-		ctx,
-		"HANA",
-	).Return(nil).
-		NotBefore(checkSaptuneVersionCall).
-		NotBefore(getAppliedSolutionCall).
-		NotBefore(changeSolutionCall).
 		Once()
 
 	suite.mockSaptuneClient.On(
@@ -318,7 +244,6 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCo
 		NotBefore(checkSaptuneVersionCall).
 		NotBefore(getAppliedSolutionCall).
 		NotBefore(changeSolutionCall).
-		NotBefore(revertSolutionCall).
 		Once()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
@@ -373,16 +298,6 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		NotBefore(initialChangeSolutionCall).
 		Once()
 
-	revertSolutionCall := suite.mockSaptuneClient.On(
-		"RevertSolution",
-		ctx,
-		"HANA",
-	).Return(nil).
-		NotBefore(checkSaptuneVersionCall).
-		NotBefore(getAppliedSolutionCall).
-		NotBefore(initialChangeSolutionCall).
-		Once()
-
 	suite.mockSaptuneClient.On(
 		"ChangeSolution",
 		ctx,
@@ -391,7 +306,6 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		NotBefore(checkSaptuneVersionCall).
 		NotBefore(getAppliedSolutionCall).
 		NotBefore(initialChangeSolutionCall).
-		NotBefore(revertSolutionCall).
 		Once()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
@@ -412,7 +326,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 	suite.Contains(report.Error.Message, "failed to determine currently applied solution in verify")
 }
 
-func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVerifyErrorGetAppliedSolutionFailingRollbackRevert() {
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVerifyErrorGetAppliedSolutionFailingRollback() {
 	ctx := context.Background()
 
 	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
@@ -441,79 +355,6 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		"GetAppliedSolution",
 		ctx,
 	).Return("", errors.New("failed to determine currently applied solution in verify")).
-		NotBefore(checkSaptuneVersionCall).
-		NotBefore(getAppliedSolutionCall).
-		NotBefore(initialChangeSolutionCall).
-		Once()
-
-	suite.mockSaptuneClient.On(
-		"RevertSolution",
-		ctx,
-		"HANA",
-	).Return(errors.New("failed to revert solution")).
-		NotBefore(checkSaptuneVersionCall).
-		NotBefore(getAppliedSolutionCall).
-		NotBefore(initialChangeSolutionCall).
-		Once()
-
-	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
-		operator.OperatorArguments{
-			"solution": "HANA",
-		},
-		"test-op",
-		operator.OperatorOptions[operator.SaptuneChangeSolution]{
-			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
-			},
-		},
-	)
-	report := saptuneSolutionChangeOperator.Run(ctx)
-
-	suite.Nil(report.Success)
-	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
-	suite.Contains(report.Error.Message, "failed to determine currently applied solution in verify")
-	suite.Contains(report.Error.Message, "failed to revert solution")
-}
-
-func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVerifyErrorGetAppliedSolutionFailingRollbackChange() {
-	ctx := context.Background()
-
-	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
-		"CheckVersionSupport",
-		ctx,
-	).Return(nil).
-		Once()
-
-	getAppliedSolutionCall := suite.mockSaptuneClient.On(
-		"GetAppliedSolution",
-		ctx,
-	).Return("FOO", nil).
-		NotBefore(checkSaptuneVersionCall).
-		Once()
-
-	initialChangeSolutionCall := suite.mockSaptuneClient.On(
-		"ChangeSolution",
-		ctx,
-		"HANA",
-	).Return(nil).
-		NotBefore(checkSaptuneVersionCall).
-		NotBefore(getAppliedSolutionCall).
-		Once()
-
-	suite.mockSaptuneClient.On(
-		"GetAppliedSolution",
-		ctx,
-	).Return("", errors.New("failed to determine currently applied solution in verify")).
-		NotBefore(checkSaptuneVersionCall).
-		NotBefore(getAppliedSolutionCall).
-		NotBefore(initialChangeSolutionCall).
-		Once()
-
-	revertSolutionCall := suite.mockSaptuneClient.On(
-		"RevertSolution",
-		ctx,
-		"HANA",
-	).Return(nil).
 		NotBefore(checkSaptuneVersionCall).
 		NotBefore(getAppliedSolutionCall).
 		NotBefore(initialChangeSolutionCall).
@@ -527,7 +368,6 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		NotBefore(checkSaptuneVersionCall).
 		NotBefore(getAppliedSolutionCall).
 		NotBefore(initialChangeSolutionCall).
-		NotBefore(revertSolutionCall).
 		Once()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
@@ -583,16 +423,6 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		NotBefore(initialChangeSolutionCall).
 		Once()
 
-	revertSolutionCall := suite.mockSaptuneClient.On(
-		"RevertSolution",
-		ctx,
-		"HANA",
-	).Return(nil).
-		NotBefore(checkSaptuneVersionCall).
-		NotBefore(getAppliedSolutionCall).
-		NotBefore(initialChangeSolutionCall).
-		Once()
-
 	suite.mockSaptuneClient.On(
 		"ChangeSolution",
 		ctx,
@@ -601,7 +431,6 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		NotBefore(checkSaptuneVersionCall).
 		NotBefore(getAppliedSolutionCall).
 		NotBefore(initialChangeSolutionCall).
-		NotBefore(revertSolutionCall).
 		Once()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
@@ -622,7 +451,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 	suite.Contains(report.Error.Message, "verify saptune apply failing, the solution HANA was not applied in commit phase")
 }
 
-func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVerifyErrorNonMatchingFailingRollbackRevert() {
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVerifyErrorNonMatchingFailingRollback() {
 	ctx := context.Background()
 
 	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
@@ -651,79 +480,6 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		"GetAppliedSolution",
 		ctx,
 	).Return("NOT_HANA", nil).
-		NotBefore(checkSaptuneVersionCall).
-		NotBefore(getAppliedSolutionCall).
-		NotBefore(initialChangeSolutionCall).
-		Once()
-
-	suite.mockSaptuneClient.On(
-		"RevertSolution",
-		ctx,
-		"HANA",
-	).Return(errors.New("failed to revert solution")).
-		NotBefore(checkSaptuneVersionCall).
-		NotBefore(getAppliedSolutionCall).
-		NotBefore(initialChangeSolutionCall).
-		Once()
-
-	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
-		operator.OperatorArguments{
-			"solution": "HANA",
-		},
-		"test-op",
-		operator.OperatorOptions[operator.SaptuneChangeSolution]{
-			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
-			},
-		},
-	)
-	report := saptuneSolutionChangeOperator.Run(ctx)
-
-	suite.Nil(report.Success)
-	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
-	suite.Contains(report.Error.Message, "verify saptune apply failing, the solution HANA was not applied in commit phase")
-	suite.Contains(report.Error.Message, "failed to revert solution")
-}
-
-func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVerifyErrorNonMatchingFailingRollbackChange() {
-	ctx := context.Background()
-
-	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
-		"CheckVersionSupport",
-		ctx,
-	).Return(nil).
-		Once()
-
-	getAppliedSolutionCall := suite.mockSaptuneClient.On(
-		"GetAppliedSolution",
-		ctx,
-	).Return("FOO", nil).
-		NotBefore(checkSaptuneVersionCall).
-		Once()
-
-	initialChangeSolutionCall := suite.mockSaptuneClient.On(
-		"ChangeSolution",
-		ctx,
-		"HANA",
-	).Return(nil).
-		NotBefore(checkSaptuneVersionCall).
-		NotBefore(getAppliedSolutionCall).
-		Once()
-
-	suite.mockSaptuneClient.On(
-		"GetAppliedSolution",
-		ctx,
-	).Return("NOT_HANA", nil).
-		NotBefore(checkSaptuneVersionCall).
-		NotBefore(getAppliedSolutionCall).
-		NotBefore(initialChangeSolutionCall).
-		Once()
-
-	revertSolutionCall := suite.mockSaptuneClient.On(
-		"RevertSolution",
-		ctx,
-		"HANA",
-	).Return(nil).
 		NotBefore(checkSaptuneVersionCall).
 		NotBefore(getAppliedSolutionCall).
 		NotBefore(initialChangeSolutionCall).
@@ -737,7 +493,6 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		NotBefore(checkSaptuneVersionCall).
 		NotBefore(getAppliedSolutionCall).
 		NotBefore(initialChangeSolutionCall).
-		NotBefore(revertSolutionCall).
 		Once()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(

--- a/pkg/operator/saptunechangesolution_v1_test.go
+++ b/pkg/operator/saptunechangesolution_v1_test.go
@@ -75,9 +75,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionPl
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](
-					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -112,9 +110,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionPl
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](
-					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -150,9 +146,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCo
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](
-					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -217,9 +211,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCo
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](
-					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -272,9 +264,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCo
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](
-					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -338,9 +328,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCo
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](
-					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -413,9 +401,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](
-					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -477,9 +463,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](
-					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -553,9 +537,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](
-					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -629,9 +611,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](
-					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -693,9 +673,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](
-					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -769,9 +747,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](
-					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -806,9 +782,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionSu
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](
-					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
 		},
 	)
@@ -865,9 +839,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionSu
 		"test-op",
 		operator.OperatorOptions[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
-				operator.Option[operator.SaptuneChangeSolution](
-					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
-				),
+				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
 		},
 	)

--- a/pkg/operator/saptunechangesolution_v1_test.go
+++ b/pkg/operator/saptunechangesolution_v1_test.go
@@ -1,0 +1,884 @@
+package operator_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/workbench/internal/saptune/mocks"
+	"github.com/trento-project/workbench/pkg/operator"
+)
+
+type SaptuneChangeSolutionOperatorTestSuite struct {
+	suite.Suite
+	mockSaptuneClient *mocks.MockSaptune
+}
+
+func TestSaptuneChangeSolutionOperator(t *testing.T) {
+	suite.Run(t, new(SaptuneChangeSolutionOperatorTestSuite))
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) SetupTest() {
+	suite.mockSaptuneClient = mocks.NewMockSaptune(suite.T())
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionPlanErrorParsingArguments() {
+	ctx := context.Background()
+
+	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
+		operator.OperatorArguments{
+			"foo": "HANA",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneChangeSolution]{},
+	)
+
+	report := saptuneSolutionChangeOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("argument solution not provided, could not use the operator", report.Error.Message)
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionPlanErrorEmptySolutionRequested() {
+	ctx := context.Background()
+
+	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
+		operator.OperatorArguments{
+			"solution": "",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneChangeSolution]{},
+	)
+
+	report := saptuneSolutionChangeOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("solution argument is empty", report.Error.Message)
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionPlanErrorVersionCheck() {
+	ctx := context.Background()
+
+	suite.mockSaptuneClient.On(
+		"CheckVersionSupport",
+		ctx,
+	).Return(errors.New("saptune version not supported")).
+		Once()
+
+	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
+		operator.OperatorArguments{
+			"solution": "HANA",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
+				operator.Option[operator.SaptuneChangeSolution](
+					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
+				),
+			},
+		},
+	)
+
+	report := saptuneSolutionChangeOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("saptune version not supported", report.Error.Message)
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionPlanErrorGettingSolution() {
+	ctx := context.Background()
+
+	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
+		"CheckVersionSupport",
+		ctx,
+	).Return(nil).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("", errors.New("failed to determine initially applied solution")).
+		NotBefore(checkSaptuneVersionCall).
+		Once()
+
+	saptuneSolutionApplyOperator := operator.NewSaptuneChangeSolution(
+		operator.OperatorArguments{
+			"solution": "HANA",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
+				operator.Option[operator.SaptuneChangeSolution](
+					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
+				),
+			},
+		},
+	)
+
+	report := saptuneSolutionApplyOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("failed to determine initially applied solution", report.Error.Message)
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCommitErrorNoPreviouslyAppliedSolution() {
+
+	ctx := context.Background()
+
+	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
+		"CheckVersionSupport",
+		ctx,
+	).Return(nil).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("", nil).
+		NotBefore(checkSaptuneVersionCall).
+		Once()
+
+	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
+		operator.OperatorArguments{
+			"solution": "HANA",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
+				operator.Option[operator.SaptuneChangeSolution](
+					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
+				),
+			},
+		},
+	)
+	report := saptuneSolutionChangeOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.COMMIT, report.Error.ErrorPhase)
+	suite.Contains(report.Error.Message, "cannot change solution to HANA because no solution is currently applied")
+
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCommitErrorChangeSolutionSuccessfulRollback() {
+	ctx := context.Background()
+
+	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
+		"CheckVersionSupport",
+		ctx,
+	).Return(nil).
+		Once()
+
+	getAppliedSolutionCall := suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("FOO", nil).
+		NotBefore(checkSaptuneVersionCall).
+		Once()
+
+	changeSolutionCall := suite.mockSaptuneClient.On(
+		"ChangeSolution",
+		ctx,
+		"HANA",
+	).Return(errors.New("failed to change solution")).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		Once()
+
+	revertSolutionCall := suite.mockSaptuneClient.On(
+		"RevertSolution",
+		ctx,
+		"HANA",
+	).Return(nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(changeSolutionCall).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"ChangeSolution",
+		ctx,
+		"FOO",
+	).Return(nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(changeSolutionCall).
+		NotBefore(revertSolutionCall).
+		Once()
+
+	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
+		operator.OperatorArguments{
+			"solution": "HANA",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
+				operator.Option[operator.SaptuneChangeSolution](
+					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
+				),
+			},
+		},
+	)
+	report := saptuneSolutionChangeOperator.Run(ctx)
+	suite.Nil(report.Success)
+	suite.Equal(operator.COMMIT, report.Error.ErrorPhase)
+	suite.Contains(report.Error.Message, "failed to change solution")
+
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCommitErrorChangeSolutionFailingRollbackRevert() {
+	ctx := context.Background()
+
+	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
+		"CheckVersionSupport",
+		ctx,
+	).Return(nil).
+		Once()
+
+	getAppliedSolutionCall := suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("FOO", nil).
+		NotBefore(checkSaptuneVersionCall).
+		Once()
+
+	changeSolutionCall := suite.mockSaptuneClient.On(
+		"ChangeSolution",
+		ctx,
+		"HANA",
+	).Return(errors.New("failed to change solution")).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"RevertSolution",
+		ctx,
+		"HANA",
+	).Return(errors.New("failed to revert solution")).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(changeSolutionCall).
+		Once()
+
+	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
+		operator.OperatorArguments{
+			"solution": "HANA",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
+				operator.Option[operator.SaptuneChangeSolution](
+					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
+				),
+			},
+		},
+	)
+	report := saptuneSolutionChangeOperator.Run(ctx)
+	suite.Nil(report.Success)
+	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
+	suite.Contains(report.Error.Message, "failed to change solution")
+	suite.Contains(report.Error.Message, "failed to revert solution")
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCommitErrorChangeSolutionFailingRollbackChange() {
+	ctx := context.Background()
+
+	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
+		"CheckVersionSupport",
+		ctx,
+	).Return(nil).
+		Once()
+
+	getAppliedSolutionCall := suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("FOO", nil).
+		NotBefore(checkSaptuneVersionCall).
+		Once()
+
+	changeSolutionCall := suite.mockSaptuneClient.On(
+		"ChangeSolution",
+		ctx,
+		"HANA",
+	).Return(errors.New("failed to change solution")).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		Once()
+
+	revertSolutionCall := suite.mockSaptuneClient.On(
+		"RevertSolution",
+		ctx,
+		"HANA",
+	).Return(nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(changeSolutionCall).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"ChangeSolution",
+		ctx,
+		"FOO",
+	).Return(errors.New("failed to change back to initial solution")).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(changeSolutionCall).
+		NotBefore(revertSolutionCall).
+		Once()
+
+	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
+		operator.OperatorArguments{
+			"solution": "HANA",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
+				operator.Option[operator.SaptuneChangeSolution](
+					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
+				),
+			},
+		},
+	)
+	report := saptuneSolutionChangeOperator.Run(ctx)
+	suite.Nil(report.Success)
+	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
+	suite.Contains(report.Error.Message, "failed to change solution")
+	suite.Contains(report.Error.Message, "failed to change back to initial solution")
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVerifyErrorGetAppliedSolutionSuccessfulRollback() {
+	ctx := context.Background()
+
+	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
+		"CheckVersionSupport",
+		ctx,
+	).Return(nil).
+		Once()
+
+	getAppliedSolutionCall := suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("FOO", nil).
+		NotBefore(checkSaptuneVersionCall).
+		Once()
+
+	initialChangeSolutionCall := suite.mockSaptuneClient.On(
+		"ChangeSolution",
+		ctx,
+		"HANA",
+	).Return(nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("", errors.New("failed to determine currently applied solution in verify")).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(initialChangeSolutionCall).
+		Once()
+
+	revertSolutionCall := suite.mockSaptuneClient.On(
+		"RevertSolution",
+		ctx,
+		"HANA",
+	).Return(nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(initialChangeSolutionCall).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"ChangeSolution",
+		ctx,
+		"FOO",
+	).Return(nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(initialChangeSolutionCall).
+		NotBefore(revertSolutionCall).
+		Once()
+
+	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
+		operator.OperatorArguments{
+			"solution": "HANA",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
+				operator.Option[operator.SaptuneChangeSolution](
+					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
+				),
+			},
+		},
+	)
+	report := saptuneSolutionChangeOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.VERIFY, report.Error.ErrorPhase)
+	suite.Contains(report.Error.Message, "failed to determine currently applied solution in verify")
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVerifyErrorGetAppliedSolutionFailingRollbackRevert() {
+	ctx := context.Background()
+
+	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
+		"CheckVersionSupport",
+		ctx,
+	).Return(nil).
+		Once()
+
+	getAppliedSolutionCall := suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("FOO", nil).
+		NotBefore(checkSaptuneVersionCall).
+		Once()
+
+	initialChangeSolutionCall := suite.mockSaptuneClient.On(
+		"ChangeSolution",
+		ctx,
+		"HANA",
+	).Return(nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("", errors.New("failed to determine currently applied solution in verify")).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(initialChangeSolutionCall).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"RevertSolution",
+		ctx,
+		"HANA",
+	).Return(errors.New("failed to revert solution")).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(initialChangeSolutionCall).
+		Once()
+
+	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
+		operator.OperatorArguments{
+			"solution": "HANA",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
+				operator.Option[operator.SaptuneChangeSolution](
+					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
+				),
+			},
+		},
+	)
+	report := saptuneSolutionChangeOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
+	suite.Contains(report.Error.Message, "failed to determine currently applied solution in verify")
+	suite.Contains(report.Error.Message, "failed to revert solution")
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVerifyErrorGetAppliedSolutionFailingRollbackChange() {
+	ctx := context.Background()
+
+	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
+		"CheckVersionSupport",
+		ctx,
+	).Return(nil).
+		Once()
+
+	getAppliedSolutionCall := suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("FOO", nil).
+		NotBefore(checkSaptuneVersionCall).
+		Once()
+
+	initialChangeSolutionCall := suite.mockSaptuneClient.On(
+		"ChangeSolution",
+		ctx,
+		"HANA",
+	).Return(nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("", errors.New("failed to determine currently applied solution in verify")).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(initialChangeSolutionCall).
+		Once()
+
+	revertSolutionCall := suite.mockSaptuneClient.On(
+		"RevertSolution",
+		ctx,
+		"HANA",
+	).Return(nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(initialChangeSolutionCall).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"ChangeSolution",
+		ctx,
+		"FOO",
+	).Return(errors.New("failed to change back to initial solution")).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(initialChangeSolutionCall).
+		NotBefore(revertSolutionCall).
+		Once()
+
+	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
+		operator.OperatorArguments{
+			"solution": "HANA",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
+				operator.Option[operator.SaptuneChangeSolution](
+					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
+				),
+			},
+		},
+	)
+	report := saptuneSolutionChangeOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
+	suite.Contains(report.Error.Message, "failed to determine currently applied solution in verify")
+	suite.Contains(report.Error.Message, "failed to change back to initial solution")
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVerifyErrorNonMatchingSuccessfulRollback() {
+	ctx := context.Background()
+
+	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
+		"CheckVersionSupport",
+		ctx,
+	).Return(nil).
+		Once()
+
+	getAppliedSolutionCall := suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("FOO", nil).
+		NotBefore(checkSaptuneVersionCall).
+		Once()
+
+	initialChangeSolutionCall := suite.mockSaptuneClient.On(
+		"ChangeSolution",
+		ctx,
+		"HANA",
+	).Return(nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("NOT_HANA", nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(initialChangeSolutionCall).
+		Once()
+
+	revertSolutionCall := suite.mockSaptuneClient.On(
+		"RevertSolution",
+		ctx,
+		"HANA",
+	).Return(nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(initialChangeSolutionCall).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"ChangeSolution",
+		ctx,
+		"FOO",
+	).Return(nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(initialChangeSolutionCall).
+		NotBefore(revertSolutionCall).
+		Once()
+
+	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
+		operator.OperatorArguments{
+			"solution": "HANA",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
+				operator.Option[operator.SaptuneChangeSolution](
+					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
+				),
+			},
+		},
+	)
+	report := saptuneSolutionChangeOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.VERIFY, report.Error.ErrorPhase)
+	suite.Contains(report.Error.Message, "verify saptune apply failing, the solution HANA was not applied in commit phase")
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVerifyErrorNonMatchingFailingRollbackRevert() {
+	ctx := context.Background()
+
+	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
+		"CheckVersionSupport",
+		ctx,
+	).Return(nil).
+		Once()
+
+	getAppliedSolutionCall := suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("FOO", nil).
+		NotBefore(checkSaptuneVersionCall).
+		Once()
+
+	initialChangeSolutionCall := suite.mockSaptuneClient.On(
+		"ChangeSolution",
+		ctx,
+		"HANA",
+	).Return(nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("NOT_HANA", nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(initialChangeSolutionCall).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"RevertSolution",
+		ctx,
+		"HANA",
+	).Return(errors.New("failed to revert solution")).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(initialChangeSolutionCall).
+		Once()
+
+	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
+		operator.OperatorArguments{
+			"solution": "HANA",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
+				operator.Option[operator.SaptuneChangeSolution](
+					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
+				),
+			},
+		},
+	)
+	report := saptuneSolutionChangeOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
+	suite.Contains(report.Error.Message, "verify saptune apply failing, the solution HANA was not applied in commit phase")
+	suite.Contains(report.Error.Message, "failed to revert solution")
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVerifyErrorNonMatchingFailingRollbackChange() {
+	ctx := context.Background()
+
+	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
+		"CheckVersionSupport",
+		ctx,
+	).Return(nil).
+		Once()
+
+	getAppliedSolutionCall := suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("FOO", nil).
+		NotBefore(checkSaptuneVersionCall).
+		Once()
+
+	initialChangeSolutionCall := suite.mockSaptuneClient.On(
+		"ChangeSolution",
+		ctx,
+		"HANA",
+	).Return(nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("NOT_HANA", nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(initialChangeSolutionCall).
+		Once()
+
+	revertSolutionCall := suite.mockSaptuneClient.On(
+		"RevertSolution",
+		ctx,
+		"HANA",
+	).Return(nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(initialChangeSolutionCall).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"ChangeSolution",
+		ctx,
+		"FOO",
+	).Return(errors.New("failed to change back to initial solution")).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(getAppliedSolutionCall).
+		NotBefore(initialChangeSolutionCall).
+		NotBefore(revertSolutionCall).
+		Once()
+
+	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
+		operator.OperatorArguments{
+			"solution": "HANA",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
+				operator.Option[operator.SaptuneChangeSolution](
+					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
+				),
+			},
+		},
+	)
+	report := saptuneSolutionChangeOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
+	suite.Contains(report.Error.Message, "verify saptune apply failing, the solution HANA was not applied in commit phase")
+	suite.Contains(report.Error.Message, "failed to change back to initial solution")
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionSuccessNoChange() {
+	ctx := context.Background()
+
+	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
+		"CheckVersionSupport",
+		ctx,
+	).Return(nil).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("HANA", nil).
+		NotBefore(checkSaptuneVersionCall).
+		Once()
+
+	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
+		operator.OperatorArguments{
+			"solution": "HANA",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
+				operator.Option[operator.SaptuneChangeSolution](
+					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
+				),
+			},
+		},
+	)
+	report := saptuneSolutionChangeOperator.Run(ctx)
+
+	expectedDiff := map[string]any{
+		"before": `{"solution":"HANA"}`,
+		"after":  `{"solution":"HANA"}`,
+	}
+
+	suite.Nil(report.Error)
+	suite.Equal(operator.VERIFY, report.Success.LastPhase)
+	suite.EqualValues(expectedDiff, report.Success.Diff)
+}
+
+func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionSuccess() {
+	ctx := context.Background()
+
+	checkSaptuneVersionCall := suite.mockSaptuneClient.On(
+		"CheckVersionSupport",
+		ctx,
+	).Return(nil).
+		Once()
+
+	initialGetAppliedSolutionCall := suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("FOO", nil).
+		NotBefore(checkSaptuneVersionCall).
+		Once()
+
+	changeSolutionCall := suite.mockSaptuneClient.On(
+		"ChangeSolution",
+		ctx,
+		"HANA",
+	).Return(nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(initialGetAppliedSolutionCall).
+		Once()
+
+	suite.mockSaptuneClient.On(
+		"GetAppliedSolution",
+		ctx,
+	).Return("HANA", nil).
+		NotBefore(checkSaptuneVersionCall).
+		NotBefore(initialGetAppliedSolutionCall).
+		NotBefore(changeSolutionCall).
+		Once()
+
+	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
+		operator.OperatorArguments{
+			"solution": "HANA",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
+				operator.Option[operator.SaptuneChangeSolution](
+					operator.WithSaptuneClient[operator.SaptuneChangeSolution](suite.mockSaptuneClient),
+				),
+			},
+		},
+	)
+	report := saptuneSolutionChangeOperator.Run(ctx)
+
+	expectedDiff := map[string]any{
+		"before": `{"solution":"FOO"}`,
+		"after":  `{"solution":"HANA"}`,
+	}
+
+	suite.Nil(report.Error)
+	suite.Equal(operator.VERIFY, report.Success.LastPhase)
+	suite.EqualValues(expectedDiff, report.Success.Diff)
+}

--- a/test/fixtures/saptune/change_solution_success.output
+++ b/test/fixtures/saptune/change_solution_success.output
@@ -1,0 +1,15 @@
+
+NOTICE: Exchange applied solution 'S4HANA-DBSERVER' with new solution 'HANA'
+WARNING: Perf Bias settings not supported by the system
+WARNING: Governor settings not supported by the system
+WARNING: Parameter 'fs.aio-max-nr' additional defined in the following sysctl config file /usr/lib/sysctl.d/99-sysctl.conf(18446744073709551615).
+NOTICE: block device related section settings detected: Traversing all block devices can take a considerable amount of time.
+WARNING: Perf Bias settings not supported by the system
+WARNING: Governor settings not supported by the system
+WARNING: Perf Bias settings not supported by the system
+WARNING: Governor settings not supported by the system
+WARNING: Perf Bias settings not supported by the system
+WARNING: Governor settings not supported by the system
+WARNING: Perf Bias settings not supported by the system
+WARNING: Governor settings not supported by the system
+All tuning options for the SAP solution have been applied successfully.

--- a/test/fixtures/saptune/change_solution_to_same_success.output
+++ b/test/fixtures/saptune/change_solution_to_same_success.output
@@ -1,0 +1,2 @@
+
+NOTICE: Solution 'HANA' already applied, nothing to do.


### PR DESCRIPTION
# Description

Adding Saptune change solution operator.

Note:
- even though a change can be issued without a previous solution being applied the operator does not allow it to keep separation between apply/change semantics
- `plan` and `operationDiff` are basically the same for the two operators meaning that we either improve the generics or we have only one operator that decides what to do based on input
- testing the operator becomes very verbose. It might be more ergonomic being able to test the specific plan/commit/verify/rollback in isolation