### PR TITLE
SAP instance start/stop

### DIFF
--- a/pkg/operator/registry.go
+++ b/pkg/operator/registry.go
@@ -106,6 +106,20 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 					})
 				},
 			},
+			SapInstanceStartOperatorName: map[string]OperatorBuilder{
+				"v1": func(operationID string, arguments OperatorArguments) Operator {
+					return NewSAPInstanceStart(arguments, operationID, OperatorOptions[SAPInstanceStart]{
+						BaseOperatorOptions: options,
+					})
+				},
+			},
+			SapInstanceStopOperatorName: map[string]OperatorBuilder{
+				"v1": func(operationID string, arguments OperatorArguments) Operator {
+					return NewSAPInstanceStop(arguments, operationID, OperatorOptions[SAPInstanceStop]{
+						BaseOperatorOptions: options,
+					})
+				},
+			},
 			SaptuneApplySolutionOperatorName: map[string]OperatorBuilder{
 				"v1": func(operationID string, arguments OperatorArguments) Operator {
 					return NewSaptuneApplySolution(arguments, operationID, OperatorOptions[SaptuneApplySolution]{

--- a/pkg/operator/sapinstancestart_v1.go
+++ b/pkg/operator/sapinstancestart_v1.go
@@ -27,6 +27,26 @@ type sapStateChangeArguments struct {
 
 type SAPInstanceStartOption Option[SAPInstanceStart]
 
+// SAPInstanceStart operator starts a SAP instance.
+//
+// Arguments:
+//	instance_number (required): String with the instance number of the instance to start
+//  timeout: Timeout in seconds to wait until the instance is started
+//
+// # Execution Phases
+//
+// - PLAN:
+//   The operator gets the instance current processes and stores the state.
+//
+// - COMMIT:
+//   If the SAP instances is not already started, it is started using the sapcontrol Start command.
+//
+// - VERIFY:
+//   Verify if the SAP instance is started.
+//
+// - ROLLBACK:
+//   If an error occurs during the COMMIT or VERIFY phase, the instance is stopped back again.
+
 type SAPInstanceStart struct {
 	baseOperator
 	parsedArguments     *sapStateChangeArguments

--- a/pkg/operator/sapinstancestart_v1.go
+++ b/pkg/operator/sapinstancestart_v1.go
@@ -1,0 +1,270 @@
+package operator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/trento-project/workbench/internal/sapcontrol"
+)
+
+const (
+	SapInstanceStartOperatorName    = "sapinstancestart"
+	defaultStartDelay               = 1 * time.Second
+	defaultSapInstanceStateTimeout  = 5 * time.Minute
+	defaultSapInstanceStateInterval = 10 * time.Second
+)
+
+type sapInstanceStartDiffOutput struct {
+	Started bool `json:"started"`
+}
+
+type sapStateChangeArguments struct {
+	instNumber string
+	timeout    time.Duration
+}
+
+type SAPInstanceStartOption Option[SAPInstanceStart]
+
+type SAPInstanceStart struct {
+	baseOperator
+	parsedArguments     *sapStateChangeArguments
+	sapControlConnector sapcontrol.SAPControlConnector
+	interval            time.Duration
+	startDelay          time.Duration
+}
+
+func WithCustomStartSapcontrol(sapControlConnector sapcontrol.SAPControlConnector) SAPInstanceStartOption {
+	return func(o *SAPInstanceStart) {
+		o.sapControlConnector = sapControlConnector
+	}
+}
+
+func WithCustomStartInterval(interval time.Duration) SAPInstanceStartOption {
+	return func(o *SAPInstanceStart) {
+		o.interval = interval
+	}
+}
+
+func WithCustomStartInitialDelay(startDelay time.Duration) SAPInstanceStartOption {
+	return func(o *SAPInstanceStart) {
+		o.startDelay = startDelay
+	}
+}
+
+func NewSAPInstanceStart(
+	arguments OperatorArguments,
+	operationID string,
+	options OperatorOptions[SAPInstanceStart],
+) *Executor {
+	sapInstanceStart := &SAPInstanceStart{
+		baseOperator: newBaseOperator(operationID, arguments, options.BaseOperatorOptions...),
+		interval:     defaultSapInstanceStateInterval,
+		startDelay:   defaultStartDelay,
+	}
+
+	for _, opt := range options.OperatorOptions {
+		opt(sapInstanceStart)
+	}
+
+	return &Executor{
+		phaser:      sapInstanceStart,
+		operationID: operationID,
+	}
+}
+
+func (s *SAPInstanceStart) plan(ctx context.Context) error {
+	opArguments, err := parseSAPStateChangeArguments(s.arguments)
+	if err != nil {
+		return err
+	}
+	s.parsedArguments = opArguments
+
+	// Use custom sapControlConnector or create a new one based on the instance_number argument
+	if s.sapControlConnector == nil {
+		s.sapControlConnector = sapcontrol.NewSAPControlConnector(s.parsedArguments.instNumber)
+	}
+
+	started, err := allProcessesInState(ctx, s.sapControlConnector, sapcontrol.STATECOLORSAPControlGREEN)
+	if err != nil {
+		return fmt.Errorf("error checking processes state: %w", err)
+	}
+
+	s.resources[beforeDiffField] = started
+
+	return nil
+}
+
+func (s *SAPInstanceStart) commit(ctx context.Context) error {
+	if s.resources[beforeDiffField] == true {
+		s.logger.Info("instance already started, skipping operation")
+		return nil
+	}
+
+	request := new(sapcontrol.Start)
+	_, err := s.sapControlConnector.StartContext(ctx, request)
+	if err != nil {
+		return fmt.Errorf("error starting instance: %w", err)
+	}
+
+	// need to wait until the processes start properly
+	err = sleepContext(ctx, s.startDelay)
+	if err != nil {
+		return err
+	}
+
+	return waitUntilSapInstanceState(
+		ctx,
+		s.sapControlConnector,
+		sapcontrol.STATECOLORSAPControlGREEN,
+		s.parsedArguments.timeout,
+		s.interval,
+	)
+}
+
+func (s *SAPInstanceStart) verify(ctx context.Context) error {
+	started, err := allProcessesInState(ctx, s.sapControlConnector, sapcontrol.STATECOLORSAPControlGREEN)
+	if err != nil {
+		return fmt.Errorf("error checking processes state: %w", err)
+	}
+
+	if started {
+		s.resources[afterDiffField] = started
+		return nil
+	}
+
+	return fmt.Errorf(
+		"verify instance started failed, instance was not started in commit phase",
+	)
+}
+
+func (s *SAPInstanceStart) rollback(ctx context.Context) error {
+	request := new(sapcontrol.Stop)
+	_, err := s.sapControlConnector.StopContext(ctx, request)
+	if err != nil {
+		return fmt.Errorf("error stopping instance: %w", err)
+	}
+
+	return waitUntilSapInstanceState(
+		ctx,
+		s.sapControlConnector,
+		sapcontrol.STATECOLORSAPControlGRAY,
+		s.parsedArguments.timeout,
+		s.interval,
+	)
+}
+
+func (s *SAPInstanceStart) operationDiff(ctx context.Context) map[string]any {
+	diff := make(map[string]any)
+
+	beforeDiffOutput := sapInstanceStartDiffOutput{
+		Started: s.resources[beforeDiffField].(bool),
+	}
+	before, _ := json.Marshal(beforeDiffOutput)
+	diff["before"] = string(before)
+
+	afterDiffOutput := sapInstanceStartDiffOutput{
+		Started: s.resources[afterDiffField].(bool),
+	}
+	after, _ := json.Marshal(afterDiffOutput)
+	diff["after"] = string(after)
+
+	return diff
+}
+
+func allProcessesInState(
+	ctx context.Context,
+	connector sapcontrol.SAPControlConnector,
+	expectedState sapcontrol.STATECOLOR,
+) (bool, error) {
+	request := new(sapcontrol.GetProcessList)
+	response, err := connector.GetProcessListContext(ctx, request)
+	if err != nil {
+		return false, fmt.Errorf("error getting instance process list: %w", err)
+	}
+
+	for _, process := range response.Processes {
+		if *process.Dispstatus != expectedState {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func waitUntilSapInstanceState(
+	ctx context.Context,
+	connector sapcontrol.SAPControlConnector,
+	expectedState sapcontrol.STATECOLOR,
+	timeout time.Duration,
+	interval time.Duration,
+) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	for {
+		inState, err := allProcessesInState(timeoutCtx, connector, expectedState)
+		if err != nil {
+			return err
+		}
+
+		if timeoutCtx.Err() != nil {
+			return fmt.Errorf("error waiting until instance is in desired state")
+		}
+
+		if inState {
+			return nil
+		}
+
+		err = sleepContext(timeoutCtx, interval)
+		if err != nil {
+			return err
+		}
+	}
+
+}
+
+// sleepContext sleeps the running thread until the interval or the context are completed
+func sleepContext(ctx context.Context, interval time.Duration) error {
+	timer := time.NewTimer(interval)
+	select {
+	case <-ctx.Done():
+		timer.Stop()
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func parseSAPStateChangeArguments(rawArguments OperatorArguments) (*sapStateChangeArguments, error) {
+	instNumberArgument, found := rawArguments["instance_number"]
+	if !found {
+		return nil, fmt.Errorf("argument instance_number not provided, could not use the operator")
+	}
+
+	instNumber, ok := instNumberArgument.(string)
+	if !ok {
+		return nil, fmt.Errorf(
+			"could not parse instance_number argument as string, argument provided: %v",
+			instNumberArgument,
+		)
+	}
+
+	timeout := defaultSapInstanceStateTimeout
+	if timeoutArgument, found := rawArguments["timeout"]; found {
+		timeoutFloat, ok := timeoutArgument.(float64)
+		if !ok {
+			return nil, fmt.Errorf(
+				"could not parse timeout argument as a number, argument provided: %v",
+				timeoutArgument,
+			)
+		}
+
+		timeout = time.Duration(int(timeoutFloat)) * time.Second
+	}
+
+	return &sapStateChangeArguments{
+		instNumber: instNumber,
+		timeout:    timeout,
+	}, nil
+}

--- a/pkg/operator/sapinstancestart_v1.go
+++ b/pkg/operator/sapinstancestart_v1.go
@@ -30,7 +30,7 @@ type SAPInstanceStartOption Option[SAPInstanceStart]
 // SAPInstanceStart operator starts a SAP instance.
 //
 // Arguments:
-//	instance_number (required): String with the instance number of the instance to start
+//  instance_number (required): String with the instance number of the instance to start
 //  timeout: Timeout in seconds to wait until the instance is started
 //
 // # Execution Phases

--- a/pkg/operator/sapinstancestart_v1_test.go
+++ b/pkg/operator/sapinstancestart_v1_test.go
@@ -1,0 +1,453 @@
+package operator_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/workbench/internal/sapcontrol"
+	"github.com/trento-project/workbench/internal/sapcontrol/mocks"
+	"github.com/trento-project/workbench/pkg/operator"
+)
+
+type SAPInstanceStartOperatorTestSuite struct {
+	suite.Suite
+	mockSapcontrol *mocks.MockSAPControlConnector
+}
+
+func TestSAPInstanceStartOperator(t *testing.T) {
+	suite.Run(t, new(SAPInstanceStartOperatorTestSuite))
+}
+
+func (suite *SAPInstanceStartOperatorTestSuite) SetupTest() {
+	suite.mockSapcontrol = mocks.NewMockSAPControlConnector(suite.T())
+}
+
+func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartInstanceNumberMissing() {
+	ctx := context.Background()
+
+	sapInstanceStartOperator := operator.NewSAPInstanceStart(
+		operator.OperatorArguments{},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStart]{},
+	)
+
+	report := sapInstanceStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("argument instance_number not provided, could not use the operator", report.Error.Message)
+}
+
+func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartInstanceNumberInvalid() {
+	ctx := context.Background()
+
+	sapInstanceStartOperator := operator.NewSAPInstanceStart(
+		operator.OperatorArguments{
+			"instance_number": 0,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStart]{},
+	)
+
+	report := sapInstanceStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("could not parse instance_number argument as string, argument provided: 0", report.Error.Message)
+}
+
+func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartTimeoutInvalid() {
+	ctx := context.Background()
+
+	sapInstanceStartOperator := operator.NewSAPInstanceStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"timeout":         "value",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStart]{},
+	)
+
+	report := sapInstanceStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("could not parse timeout argument as a number, argument provided: value", report.Error.Message)
+}
+
+func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartPlanError() {
+	ctx := context.Background()
+
+	suite.mockSapcontrol.On(
+		"GetProcessListContext",
+		ctx,
+		mock.Anything,
+	).Return(nil, errors.New("error getting processes")).
+		Once()
+
+	sapInstanceStartOperator := operator.NewSAPInstanceStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"timeout":         300.0,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStart]{
+			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
+				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapInstanceStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("error checking processes state: error getting instance process list: error getting processes", report.Error.Message)
+}
+
+func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartCommitAlreadyStarted() {
+	ctx := context.Background()
+
+	green := sapcontrol.STATECOLORSAPControlGREEN
+
+	suite.mockSapcontrol.On(
+		"GetProcessListContext",
+		ctx,
+		mock.Anything,
+	).Return(&sapcontrol.GetProcessListResponse{
+		Processes: []*sapcontrol.OSProcess{
+			{
+				Dispstatus: &green,
+			},
+			{
+				Dispstatus: &green,
+			},
+		},
+	}, nil)
+
+	sapInstanceStartOperator := operator.NewSAPInstanceStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStart]{
+			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
+				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapInstanceStartOperator.Run(ctx)
+
+	expectedDiff := map[string]any{
+		"before": `{"started":true}`,
+		"after":  `{"started":true}`,
+	}
+
+	suite.Nil(report.Error)
+	suite.Equal(operator.VERIFY, report.Success.LastPhase)
+	suite.EqualValues(expectedDiff, report.Success.Diff)
+}
+
+func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartCommitStartingError() {
+	ctx := context.Background()
+
+	gray := sapcontrol.STATECOLORSAPControlGRAY
+
+	suite.mockSapcontrol.On(
+		"GetProcessListContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		&sapcontrol.GetProcessListResponse{
+			Processes: []*sapcontrol.OSProcess{
+				{
+					Dispstatus: &gray,
+				},
+			},
+		}, nil,
+	).Once().On(
+		"GetProcessListContext",
+		mock.Anything,
+		mock.Anything,
+	).Return(
+		&sapcontrol.GetProcessListResponse{
+			Processes: []*sapcontrol.OSProcess{
+				{
+					Dispstatus: &gray,
+				},
+			},
+		}, nil,
+	).On(
+		"StartContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		nil, errors.New("error starting"),
+	).On(
+		"StopContext",
+		ctx,
+		mock.Anything,
+	).Return(nil, nil)
+
+	sapInstanceStartOperator := operator.NewSAPInstanceStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStart]{
+			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
+				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapInstanceStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.COMMIT, report.Error.ErrorPhase)
+	suite.EqualValues("error starting instance: error starting", report.Error.Message)
+}
+
+func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartCommitStartingTimeout() {
+	ctx := context.Background()
+
+	gray := sapcontrol.STATECOLORSAPControlGRAY
+
+	suite.mockSapcontrol.On(
+		"GetProcessListContext",
+		mock.Anything,
+		mock.Anything,
+	).Return(
+		&sapcontrol.GetProcessListResponse{
+			Processes: []*sapcontrol.OSProcess{
+				{
+					Dispstatus: &gray,
+				},
+			},
+		}, nil,
+	).On(
+		"StartContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		nil, nil,
+	).On(
+		"StopContext",
+		ctx,
+		mock.Anything,
+	).Return(nil, nil)
+
+	sapInstanceStartOperator := operator.NewSAPInstanceStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"timeout":         0.0,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStart]{
+			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
+				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
+				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartInitialDelay(0 * time.Second)),
+				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartInterval(0 * time.Second)),
+			},
+		},
+	)
+
+	report := sapInstanceStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
+	suite.EqualValues("error waiting until instance is in desired state\n"+
+		"error waiting until instance is in desired state", report.Error.Message)
+}
+
+func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartVerifyError() {
+	ctx := context.Background()
+
+	gray := sapcontrol.STATECOLORSAPControlGRAY
+	green := sapcontrol.STATECOLORSAPControlGREEN
+
+	suite.mockSapcontrol.On(
+		"GetProcessListContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		&sapcontrol.GetProcessListResponse{
+			Processes: []*sapcontrol.OSProcess{
+				{
+					Dispstatus: &gray,
+				},
+			},
+		}, nil,
+	).Once().On(
+		"StartContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		nil, nil,
+	).On(
+		"GetProcessListContext",
+		mock.Anything,
+		mock.Anything,
+	).Return(
+		&sapcontrol.GetProcessListResponse{
+			Processes: []*sapcontrol.OSProcess{
+				{
+					Dispstatus: &green,
+				},
+			},
+		}, nil,
+	).Once().On(
+		"GetProcessListContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		nil, errors.New("error getting processes in verify"),
+	).Once().On(
+		"StopContext",
+		ctx,
+		mock.Anything,
+	).Return(nil, nil).On(
+		"GetProcessListContext",
+		mock.Anything,
+		mock.Anything,
+	).Return(
+		&sapcontrol.GetProcessListResponse{
+			Processes: []*sapcontrol.OSProcess{
+				{
+					Dispstatus: &gray,
+				},
+			},
+		}, nil,
+	)
+
+	sapInstanceStartOperator := operator.NewSAPInstanceStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStart]{
+			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
+				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
+				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartInitialDelay(0 * time.Second)),
+			},
+		},
+	)
+
+	report := sapInstanceStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.VERIFY, report.Error.ErrorPhase)
+	suite.EqualValues("error checking processes state: error getting instance process list: error getting processes in verify", report.Error.Message)
+}
+
+func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartRollbackStoppingError() {
+	ctx := context.Background()
+
+	gray := sapcontrol.STATECOLORSAPControlGRAY
+
+	suite.mockSapcontrol.On(
+		"GetProcessListContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		&sapcontrol.GetProcessListResponse{
+			Processes: []*sapcontrol.OSProcess{
+				{
+					Dispstatus: &gray,
+				},
+			},
+		}, nil,
+	).On(
+		"StartContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		nil, errors.New("error starting"),
+	).On(
+		"StopContext",
+		ctx,
+		mock.Anything,
+	).Return(nil, errors.New("error stopping"))
+
+	sapInstanceStartOperator := operator.NewSAPInstanceStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStart]{
+			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
+				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapInstanceStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
+	suite.EqualValues("error stopping instance: error stopping\nerror starting instance: error starting", report.Error.Message)
+}
+
+func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartSuccess() {
+	ctx := context.Background()
+
+	green := sapcontrol.STATECOLORSAPControlGREEN
+	gray := sapcontrol.STATECOLORSAPControlGRAY
+
+	suite.mockSapcontrol.On(
+		"GetProcessListContext",
+		ctx,
+		mock.Anything,
+	).Return(&sapcontrol.GetProcessListResponse{
+		Processes: []*sapcontrol.OSProcess{
+			{
+				Dispstatus: &gray,
+			},
+		},
+	}, nil).Once().On(
+		"GetProcessListContext",
+		mock.Anything,
+		mock.Anything,
+	).Return(&sapcontrol.GetProcessListResponse{
+		Processes: []*sapcontrol.OSProcess{
+			{
+				Dispstatus: &green,
+			},
+		},
+	}, nil).On(
+		"StartContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		nil, nil,
+	)
+
+	sapInstanceStartOperator := operator.NewSAPInstanceStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStart]{
+			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
+				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
+				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartInitialDelay(0 * time.Second)),
+			},
+		},
+	)
+
+	report := sapInstanceStartOperator.Run(ctx)
+
+	expectedDiff := map[string]any{
+		"before": `{"started":false}`,
+		"after":  `{"started":true}`,
+	}
+
+	suite.Nil(report.Error)
+	suite.Equal(operator.VERIFY, report.Success.LastPhase)
+	suite.EqualValues(expectedDiff, report.Success.Diff)
+}

--- a/pkg/operator/sapinstancestart_v1_test.go
+++ b/pkg/operator/sapinstancestart_v1_test.go
@@ -124,7 +124,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartCommitAlread
 				},
 			},
 		}, nil).
-		Twice()
+		Once()
 
 	sapInstanceStartOperator := operator.NewSAPInstanceStart(
 		operator.OperatorArguments{
@@ -147,7 +147,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartCommitAlread
 	}
 
 	suite.Nil(report.Error)
-	suite.Equal(operator.VERIFY, report.Success.LastPhase)
+	suite.Equal(operator.PLAN, report.Success.LastPhase)
 	suite.EqualValues(expectedDiff, report.Success.Diff)
 }
 

--- a/pkg/operator/sapinstancestop_v1.go
+++ b/pkg/operator/sapinstancestop_v1.go
@@ -1,0 +1,152 @@
+package operator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/trento-project/workbench/internal/sapcontrol"
+)
+
+const (
+	SapInstanceStopOperatorName = "sapinstancestop"
+)
+
+type sapInstanceStopDiffOutput struct {
+	Stopped bool `json:"stopped"`
+}
+
+type SAPInstanceStopOption Option[SAPInstanceStop]
+
+type SAPInstanceStop struct {
+	baseOperator
+	parsedArguments     *sapStateChangeArguments
+	sapControlConnector sapcontrol.SAPControlConnector
+	interval            time.Duration
+}
+
+func WithCustomStopSapcontrol(sapControlConnector sapcontrol.SAPControlConnector) SAPInstanceStopOption {
+	return func(o *SAPInstanceStop) {
+		o.sapControlConnector = sapControlConnector
+	}
+}
+
+func WithCustomStopInterval(interval time.Duration) SAPInstanceStopOption {
+	return func(o *SAPInstanceStop) {
+		o.interval = interval
+	}
+}
+
+func NewSAPInstanceStop(
+	arguments OperatorArguments,
+	operationID string,
+	options OperatorOptions[SAPInstanceStop],
+) *Executor {
+	sapInstanceStop := &SAPInstanceStop{
+		baseOperator: newBaseOperator(operationID, arguments, options.BaseOperatorOptions...),
+		interval:     defaultSapInstanceStateInterval,
+	}
+
+	for _, opt := range options.OperatorOptions {
+		opt(sapInstanceStop)
+	}
+
+	return &Executor{
+		phaser:      sapInstanceStop,
+		operationID: operationID,
+	}
+}
+
+func (s *SAPInstanceStop) plan(ctx context.Context) error {
+	opArguments, err := parseSAPStateChangeArguments(s.arguments)
+	if err != nil {
+		return err
+	}
+	s.parsedArguments = opArguments
+
+	// Use custom sapControlConnector or create a new one based on the instance_number argument
+	if s.sapControlConnector == nil {
+		s.sapControlConnector = sapcontrol.NewSAPControlConnector(s.parsedArguments.instNumber)
+	}
+
+	stopped, err := allProcessesInState(ctx, s.sapControlConnector, sapcontrol.STATECOLORSAPControlGRAY)
+	if err != nil {
+		return fmt.Errorf("error checking processes state: %w", err)
+	}
+
+	s.resources[beforeDiffField] = stopped
+
+	return nil
+}
+
+func (s *SAPInstanceStop) commit(ctx context.Context) error {
+	if s.resources[beforeDiffField] == true {
+		s.logger.Info("instance already stopped, skipping operation")
+		return nil
+	}
+
+	request := new(sapcontrol.Stop)
+	_, err := s.sapControlConnector.StopContext(ctx, request)
+	if err != nil {
+		return fmt.Errorf("error stopping instance: %w", err)
+	}
+
+	return waitUntilSapInstanceState(
+		ctx,
+		s.sapControlConnector,
+		sapcontrol.STATECOLORSAPControlGRAY,
+		s.parsedArguments.timeout,
+		s.interval,
+	)
+}
+
+func (s *SAPInstanceStop) verify(ctx context.Context) error {
+	stopped, err := allProcessesInState(ctx, s.sapControlConnector, sapcontrol.STATECOLORSAPControlGRAY)
+	if err != nil {
+		return fmt.Errorf("error checking processes state: %w", err)
+	}
+
+	if stopped {
+		s.resources[afterDiffField] = stopped
+		return nil
+	}
+
+	return fmt.Errorf(
+		"verify instance stopped failed, instance was not stopped in commit phase",
+	)
+}
+
+func (s *SAPInstanceStop) rollback(ctx context.Context) error {
+	request := new(sapcontrol.Start)
+	_, err := s.sapControlConnector.StartContext(ctx, request)
+	if err != nil {
+		return fmt.Errorf("error starting instance: %w", err)
+	}
+
+	return waitUntilSapInstanceState(
+		ctx,
+		s.sapControlConnector,
+		sapcontrol.STATECOLORSAPControlGREEN,
+		s.parsedArguments.timeout,
+		s.interval,
+	)
+}
+
+func (s *SAPInstanceStop) operationDiff(ctx context.Context) map[string]any {
+	diff := make(map[string]any)
+
+	beforeDiffOutput := sapInstanceStopDiffOutput{
+		Stopped: s.resources[beforeDiffField].(bool),
+	}
+	before, _ := json.Marshal(beforeDiffOutput)
+	diff["before"] = string(before)
+
+	afterDiffOutput := sapInstanceStopDiffOutput{
+		Stopped: s.resources[afterDiffField].(bool),
+	}
+	after, _ := json.Marshal(afterDiffOutput)
+	diff["after"] = string(after)
+
+	return diff
+}

--- a/pkg/operator/sapinstancestop_v1.go
+++ b/pkg/operator/sapinstancestop_v1.go
@@ -38,6 +38,26 @@ func WithCustomStopInterval(interval time.Duration) SAPInstanceStopOption {
 	}
 }
 
+// NewSAPInstanceStop operator stops a SAP instance.
+//
+// Arguments:
+//	instance_number (required): String with the instance number of the instance to stop
+//  timeout: Timeout in seconds to wait until the instance is stopped
+//
+// # Execution Phases
+//
+// - PLAN:
+//   The operator gets the instance current processes and stores the state.
+//
+// - COMMIT:
+//   If the SAP instances is not already stopped, it is started using the sapcontrol Stop command.
+//
+// - VERIFY:
+//   Verify if the SAP instance is stopped.
+//
+// - ROLLBACK:
+//   If an error occurs during the COMMIT or VERIFY phase, the instance is started back again.
+
 func NewSAPInstanceStop(
 	arguments OperatorArguments,
 	operationID string,

--- a/pkg/operator/sapinstancestop_v1.go
+++ b/pkg/operator/sapinstancestop_v1.go
@@ -41,7 +41,7 @@ func WithCustomStopInterval(interval time.Duration) SAPInstanceStopOption {
 // NewSAPInstanceStop operator stops a SAP instance.
 //
 // Arguments:
-//	instance_number (required): String with the instance number of the instance to stop
+//  instance_number (required): String with the instance number of the instance to stop
 //  timeout: Timeout in seconds to wait until the instance is stopped
 //
 // # Execution Phases

--- a/pkg/operator/sapinstancestop_v1_test.go
+++ b/pkg/operator/sapinstancestop_v1_test.go
@@ -1,0 +1,450 @@
+package operator_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/workbench/internal/sapcontrol"
+	"github.com/trento-project/workbench/internal/sapcontrol/mocks"
+	"github.com/trento-project/workbench/pkg/operator"
+)
+
+type SAPInstanceStopOperatorTestSuite struct {
+	suite.Suite
+	mockSapcontrol *mocks.MockSAPControlConnector
+}
+
+func TestSAPInstanceStopOperator(t *testing.T) {
+	suite.Run(t, new(SAPInstanceStopOperatorTestSuite))
+}
+
+func (suite *SAPInstanceStopOperatorTestSuite) SetupTest() {
+	suite.mockSapcontrol = mocks.NewMockSAPControlConnector(suite.T())
+}
+
+func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopInstanceNumberMissing() {
+	ctx := context.Background()
+
+	sapInstanceStopOperator := operator.NewSAPInstanceStop(
+		operator.OperatorArguments{},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStop]{},
+	)
+
+	report := sapInstanceStopOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("argument instance_number not provided, could not use the operator", report.Error.Message)
+}
+
+func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopInstanceNumberInvalid() {
+	ctx := context.Background()
+
+	sapInstanceStopOperator := operator.NewSAPInstanceStop(
+		operator.OperatorArguments{
+			"instance_number": 0,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStop]{},
+	)
+
+	report := sapInstanceStopOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("could not parse instance_number argument as string, argument provided: 0", report.Error.Message)
+}
+
+func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopTimeoutInvalid() {
+	ctx := context.Background()
+
+	sapInstanceStopOperator := operator.NewSAPInstanceStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"timeout":         "value",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStop]{},
+	)
+
+	report := sapInstanceStopOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("could not parse timeout argument as a number, argument provided: value", report.Error.Message)
+}
+
+func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopPlanError() {
+	ctx := context.Background()
+
+	suite.mockSapcontrol.On(
+		"GetProcessListContext",
+		ctx,
+		mock.Anything,
+	).Return(nil, errors.New("error getting processes")).
+		Once()
+
+	sapInstanceStopOperator := operator.NewSAPInstanceStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"timeout":         300.0,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStop]{
+			OperatorOptions: []operator.Option[operator.SAPInstanceStop]{
+				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapInstanceStopOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("error checking processes state: error getting instance process list: error getting processes", report.Error.Message)
+}
+
+func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopCommitAlreadyStopped() {
+	ctx := context.Background()
+
+	gray := sapcontrol.STATECOLORSAPControlGRAY
+
+	suite.mockSapcontrol.On(
+		"GetProcessListContext",
+		ctx,
+		mock.Anything,
+	).Return(&sapcontrol.GetProcessListResponse{
+		Processes: []*sapcontrol.OSProcess{
+			{
+				Dispstatus: &gray,
+			},
+			{
+				Dispstatus: &gray,
+			},
+		},
+	}, nil)
+
+	sapInstanceStopOperator := operator.NewSAPInstanceStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStop]{
+			OperatorOptions: []operator.Option[operator.SAPInstanceStop]{
+				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapInstanceStopOperator.Run(ctx)
+
+	expectedDiff := map[string]any{
+		"before": `{"stopped":true}`,
+		"after":  `{"stopped":true}`,
+	}
+
+	suite.Nil(report.Error)
+	suite.Equal(operator.VERIFY, report.Success.LastPhase)
+	suite.EqualValues(expectedDiff, report.Success.Diff)
+}
+
+func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopCommitStoppingError() {
+	ctx := context.Background()
+
+	green := sapcontrol.STATECOLORSAPControlGREEN
+
+	suite.mockSapcontrol.On(
+		"GetProcessListContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		&sapcontrol.GetProcessListResponse{
+			Processes: []*sapcontrol.OSProcess{
+				{
+					Dispstatus: &green,
+				},
+			},
+		}, nil,
+	).Once().On(
+		"GetProcessListContext",
+		mock.Anything,
+		mock.Anything,
+	).Return(
+		&sapcontrol.GetProcessListResponse{
+			Processes: []*sapcontrol.OSProcess{
+				{
+					Dispstatus: &green,
+				},
+			},
+		}, nil,
+	).On(
+		"StopContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		nil, errors.New("error stopping"),
+	).On(
+		"StartContext",
+		ctx,
+		mock.Anything,
+	).Return(nil, nil)
+
+	sapInstanceStopOperator := operator.NewSAPInstanceStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStop]{
+			OperatorOptions: []operator.Option[operator.SAPInstanceStop]{
+				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapInstanceStopOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.COMMIT, report.Error.ErrorPhase)
+	suite.EqualValues("error stopping instance: error stopping", report.Error.Message)
+}
+
+func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopCommitStoppingTimeout() {
+	ctx := context.Background()
+
+	green := sapcontrol.STATECOLORSAPControlGREEN
+
+	suite.mockSapcontrol.On(
+		"GetProcessListContext",
+		mock.Anything,
+		mock.Anything,
+	).Return(
+		&sapcontrol.GetProcessListResponse{
+			Processes: []*sapcontrol.OSProcess{
+				{
+					Dispstatus: &green,
+				},
+			},
+		}, nil,
+	).On(
+		"StopContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		nil, nil,
+	).On(
+		"StartContext",
+		ctx,
+		mock.Anything,
+	).Return(nil, nil)
+
+	sapInstanceStopOperator := operator.NewSAPInstanceStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"timeout":         0.0,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStop]{
+			OperatorOptions: []operator.Option[operator.SAPInstanceStop]{
+				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopSapcontrol(suite.mockSapcontrol)),
+				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopInterval(0 * time.Second)),
+			},
+		},
+	)
+
+	report := sapInstanceStopOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
+	suite.EqualValues("error waiting until instance is in desired state\n"+
+		"error waiting until instance is in desired state", report.Error.Message)
+}
+
+func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopVerifyError() {
+	ctx := context.Background()
+
+	gray := sapcontrol.STATECOLORSAPControlGRAY
+	green := sapcontrol.STATECOLORSAPControlGREEN
+
+	suite.mockSapcontrol.On(
+		"GetProcessListContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		&sapcontrol.GetProcessListResponse{
+			Processes: []*sapcontrol.OSProcess{
+				{
+					Dispstatus: &green,
+				},
+			},
+		}, nil,
+	).Once().On(
+		"StopContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		nil, nil,
+	).On(
+		"GetProcessListContext",
+		mock.Anything,
+		mock.Anything,
+	).Return(
+		&sapcontrol.GetProcessListResponse{
+			Processes: []*sapcontrol.OSProcess{
+				{
+					Dispstatus: &gray,
+				},
+			},
+		}, nil,
+	).Once().On(
+		"GetProcessListContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		nil, errors.New("error getting processes in verify"),
+	).Once().On(
+		"StartContext",
+		ctx,
+		mock.Anything,
+	).Return(nil, nil).On(
+		"GetProcessListContext",
+		mock.Anything,
+		mock.Anything,
+	).Return(
+		&sapcontrol.GetProcessListResponse{
+			Processes: []*sapcontrol.OSProcess{
+				{
+					Dispstatus: &green,
+				},
+			},
+		}, nil,
+	)
+
+	sapInstanceStopOperator := operator.NewSAPInstanceStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStop]{
+			OperatorOptions: []operator.Option[operator.SAPInstanceStop]{
+				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapInstanceStopOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.VERIFY, report.Error.ErrorPhase)
+	suite.EqualValues("error checking processes state: error getting instance process list: error getting processes in verify", report.Error.Message)
+}
+
+func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopRollbackStartingError() {
+	ctx := context.Background()
+
+	green := sapcontrol.STATECOLORSAPControlGREEN
+
+	suite.mockSapcontrol.On(
+		"GetProcessListContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		&sapcontrol.GetProcessListResponse{
+			Processes: []*sapcontrol.OSProcess{
+				{
+					Dispstatus: &green,
+				},
+			},
+		}, nil,
+	).On(
+		"StopContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		nil, errors.New("error starting"),
+	).On(
+		"StartContext",
+		ctx,
+		mock.Anything,
+	).Return(nil, errors.New("error starting"))
+
+	sapInstanceStopOperator := operator.NewSAPInstanceStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStop]{
+			OperatorOptions: []operator.Option[operator.SAPInstanceStop]{
+				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapInstanceStopOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
+	suite.EqualValues("error starting instance: error starting\nerror stopping instance: error starting", report.Error.Message)
+}
+
+func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopSuccess() {
+	ctx := context.Background()
+
+	green := sapcontrol.STATECOLORSAPControlGREEN
+	gray := sapcontrol.STATECOLORSAPControlGRAY
+
+	suite.mockSapcontrol.On(
+		"GetProcessListContext",
+		ctx,
+		mock.Anything,
+	).Return(&sapcontrol.GetProcessListResponse{
+		Processes: []*sapcontrol.OSProcess{
+			{
+				Dispstatus: &green,
+			},
+		},
+	}, nil).Once().On(
+		"GetProcessListContext",
+		mock.Anything,
+		mock.Anything,
+	).Return(&sapcontrol.GetProcessListResponse{
+		Processes: []*sapcontrol.OSProcess{
+			{
+				Dispstatus: &gray,
+			},
+		},
+	}, nil).On(
+		"StopContext",
+		ctx,
+		mock.Anything,
+	).Return(
+		nil, nil,
+	)
+
+	sapInstanceStopOperator := operator.NewSAPInstanceStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPInstanceStop]{
+			OperatorOptions: []operator.Option[operator.SAPInstanceStop]{
+				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapInstanceStopOperator.Run(ctx)
+
+	expectedDiff := map[string]any{
+		"before": `{"stopped":false}`,
+		"after":  `{"stopped":true}`,
+	}
+
+	suite.Nil(report.Error)
+	suite.Equal(operator.VERIFY, report.Success.LastPhase)
+	suite.EqualValues(expectedDiff, report.Success.Diff)
+}

--- a/pkg/operator/sapinstancestop_v1_test.go
+++ b/pkg/operator/sapinstancestop_v1_test.go
@@ -124,7 +124,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopCommitAlreadyS
 				},
 			},
 		}, nil).
-		Twice()
+		Once()
 
 	sapInstanceStopOperator := operator.NewSAPInstanceStop(
 		operator.OperatorArguments{
@@ -146,7 +146,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopCommitAlreadyS
 	}
 
 	suite.Nil(report.Error)
-	suite.Equal(operator.VERIFY, report.Success.LastPhase)
+	suite.Equal(operator.PLAN, report.Success.LastPhase)
 	suite.EqualValues(expectedDiff, report.Success.Diff)
 }
 


### PR DESCRIPTION
# Description
Add SAP instance start/stop operators.
They are pretty simple. Simply use `sapcontrol` start/stop functions when needed.
It uses the `GetProcessList` function know the current state of the instance.

It requires the `instance_number` as a mandatory argument to know which instance on the host to change.

PD:
I have thought a lot on having one operator for both options. Something like `SapInstanceChangeState`. The thing is that even though you reduce a bit the code (well, a fair bit), the code looks more confusing in general. It takes more time to understand what's going on, it is easier to make mistakes.
So in general, I think that having 2, even though they are really similar is better for code clarity and maintenance.
Many of the function are reused anyway.

## How was this tested?
UT
