### PR TITLE
Plan already applied

### DIFF
--- a/pkg/operator/clustermaintenancechange_v1_test.go
+++ b/pkg/operator/clustermaintenancechange_v1_test.go
@@ -959,7 +959,7 @@ func TestClusterMaintenanceChangeCommitAlreadyApplied(t *testing.T) {
 	}
 
 	assert.Nil(t, report.Error)
-	assert.Equal(t, report.Success.LastPhase, operator.VERIFY)
+	assert.Equal(t, report.Success.LastPhase, operator.PLAN)
 	assert.EqualValues(t, report.Success.Diff, expectedDiff)
 }
 

--- a/pkg/operator/executor.go
+++ b/pkg/operator/executor.go
@@ -6,7 +6,7 @@ import (
 )
 
 type phaser interface {
-	plan(ctx context.Context) error
+	plan(ctx context.Context) (bool, error)
 	commit(ctx context.Context) error
 	rollback(ctx context.Context) error
 	verify(ctx context.Context) error
@@ -21,9 +21,14 @@ type Executor struct {
 
 func (e *Executor) Run(ctx context.Context) *ExecutionReport {
 	e.currentPhase = PLAN
-	err := e.phaser.plan(ctx)
+	alreadyApplied, err := e.phaser.plan(ctx)
 	if err != nil {
 		return executionReportWithError(err, e.currentPhase, e.operationID)
+	}
+
+	if alreadyApplied {
+		diff := e.phaser.operationDiff(ctx)
+		return executionReportWithSuccess(diff, e.currentPhase, e.operationID)
 	}
 
 	e.currentPhase = COMMIT

--- a/pkg/operator/executor.go
+++ b/pkg/operator/executor.go
@@ -6,7 +6,7 @@ import (
 )
 
 type phaser interface {
-	plan(ctx context.Context) (bool, error)
+	plan(ctx context.Context) (alreadyApplied bool, err error)
 	commit(ctx context.Context) error
 	rollback(ctx context.Context) error
 	verify(ctx context.Context) error

--- a/pkg/operator/mock_phaser.go
+++ b/pkg/operator/mock_phaser.go
@@ -108,17 +108,27 @@ func (_c *Mockphaser_operationDiff_Call) RunAndReturn(run func(context.Context) 
 }
 
 // plan provides a mock function with given fields: ctx
-func (_m *Mockphaser) plan(ctx context.Context) error {
+func (_m *Mockphaser) plan(ctx context.Context) (bool, error) {
 	ret := _m.Called(ctx)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (bool, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) bool); ok {
 		r0 = rf(ctx)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(bool)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // Mockphaser_plan_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'plan'
@@ -139,12 +149,12 @@ func (_c *Mockphaser_plan_Call) Run(run func(ctx context.Context)) *Mockphaser_p
 	return _c
 }
 
-func (_c *Mockphaser_plan_Call) Return(_a0 error) *Mockphaser_plan_Call {
-	_c.Call.Return(_a0)
+func (_c *Mockphaser_plan_Call) Return(_a0 bool, _a1 error) *Mockphaser_plan_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *Mockphaser_plan_Call) RunAndReturn(run func(context.Context) error) *Mockphaser_plan_Call {
+func (_c *Mockphaser_plan_Call) RunAndReturn(run func(context.Context) (bool, error)) *Mockphaser_plan_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/operator/saptuneapplysolution_v1_test.go
+++ b/pkg/operator/saptuneapplysolution_v1_test.go
@@ -585,7 +585,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionSucc
 		ctx,
 	).Return("HANA", nil).
 		NotBefore(checkSaptuneVersionCall).
-		Times(2)
+		Once()
 
 	saptuneSolutionApplyOperator := operator.NewSaptuneApplySolution(
 		operator.OperatorArguments{
@@ -607,6 +607,6 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionSucc
 	}
 
 	suite.Nil(report.Error)
-	suite.Equal(operator.VERIFY, report.Success.LastPhase)
+	suite.Equal(operator.PLAN, report.Success.LastPhase)
 	suite.EqualValues(expectedDiff, report.Success.Diff)
 }

--- a/pkg/operator/saptunechangesolution_v1_test.go
+++ b/pkg/operator/saptunechangesolution_v1_test.go
@@ -549,7 +549,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionSu
 	}
 
 	suite.Nil(report.Error)
-	suite.Equal(operator.VERIFY, report.Success.LastPhase)
+	suite.Equal(operator.PLAN, report.Success.LastPhase)
 	suite.EqualValues(expectedDiff, report.Success.Diff)
 }
 


### PR DESCRIPTION
# Description

Add `alreadyApplied` return value to `plan` phase.
We are already seeing that going to commit/verify when the change is already applied can be error prone (some commands or actions can fail in the host machine).

This new `alreadyApplied` is used to skip `commit/verify` steps in the execution, so we avoid these potential errors and actually the number of system calls (commands, etc).

What do you think?

## How was this tested?

UT
