### PR TITLE
Replace initial delay by checking empty processes list

### DIFF
--- a/pkg/operator/sapinstancestart_v1_test.go
+++ b/pkg/operator/sapinstancestart_v1_test.go
@@ -134,7 +134,6 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartCommitAlread
 		operator.OperatorOptions[operator.SAPInstanceStart]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
-				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartInitialDelay(0 * time.Second)),
 			},
 		},
 	)
@@ -259,7 +258,6 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartVerifyError(
 		operator.OperatorOptions[operator.SAPInstanceStart]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
-				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartInitialDelay(0 * time.Second)),
 			},
 		},
 	)
@@ -302,7 +300,6 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartVerifyTimeou
 		operator.OperatorOptions[operator.SAPInstanceStart]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
-				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartInitialDelay(0 * time.Second)),
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartInterval(0 * time.Second)),
 			},
 		},
@@ -399,7 +396,6 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartSuccess() {
 		operator.OperatorOptions[operator.SAPInstanceStart]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
-				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartInitialDelay(0 * time.Second)),
 			},
 		},
 	)
@@ -442,6 +438,12 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartSuccessMulti
 
 	suite.mockSapcontrol.
 		On("GetProcessListContext", mock.Anything, mock.Anything).
+		Return(&sapcontrol.GetProcessListResponse{
+			Processes: []*sapcontrol.OSProcess{},
+		}, nil).
+		Twice().
+		NotBefore(planGetProcesses).
+		On("GetProcessListContext", mock.Anything, mock.Anything).
 		Return(
 			&sapcontrol.GetProcessListResponse{
 				Processes: []*sapcontrol.OSProcess{
@@ -474,7 +476,6 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartSuccessMulti
 		operator.OperatorOptions[operator.SAPInstanceStart]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
-				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartInitialDelay(0 * time.Second)),
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartInterval(0 * time.Second)),
 			},
 		},


### PR DESCRIPTION
# Description

After doing some more tests in different instances (ASCS/ERS/ABAP/HANA), the initial delay usage is not working properly in the `start_instance` operator.
The time the processes list is empty is different. 
For that reason, this changes the initial delay usage by checking for empty list of processes (I don't know why I didn't do initially).

The issue is that when you do the `Start` function of sapcontrol, the `GetProcessList` returns an empty list for some seconds.
So it is better to discard the empty returns instead of doing a sleep delay.

## How was this tested?

UT and real infra
