### PR TITLE
Add SAP system start operator

### DIFF
--- a/internal/sapcontrol/webservice.go
+++ b/internal/sapcontrol/webservice.go
@@ -88,8 +88,8 @@ type GetSystemInstanceList struct {
 }
 
 type GetSystemInstanceListResponse struct {
-	XMLName  xml.Name       `xml:"urn:SAPControl GetSystemInstanceListResponse"`
-	Instance []*SAPInstance `xml:"instance>item,omitempty" json:"instance>item,omitempty"`
+	XMLName   xml.Name       `xml:"urn:SAPControl GetSystemInstanceListResponse"`
+	Instances []*SAPInstance `xml:"instance>item,omitempty" json:"instance>item,omitempty"`
 }
 
 type SAPInstance struct {

--- a/pkg/operator/registry.go
+++ b/pkg/operator/registry.go
@@ -120,6 +120,13 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 					})
 				},
 			},
+			SapSystemStartOperatorName: map[string]OperatorBuilder{
+				"v1": func(operationID string, arguments OperatorArguments) Operator {
+					return NewSAPSystemStart(arguments, operationID, OperatorOptions[SAPSystemStart]{
+						BaseOperatorOptions: options,
+					})
+				},
+			},
 			SaptuneApplySolutionOperatorName: map[string]OperatorBuilder{
 				"v1": func(operationID string, arguments OperatorArguments) Operator {
 					return NewSaptuneApplySolution(arguments, operationID, OperatorOptions[SaptuneApplySolution]{

--- a/pkg/operator/sapsystemstart_v1.go
+++ b/pkg/operator/sapsystemstart_v1.go
@@ -1,0 +1,325 @@
+package operator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/trento-project/workbench/internal/sapcontrol"
+)
+
+const (
+	SapSystemStartOperatorName        = "sapsystemstart"
+	defaultSapSystemStateTimeout      = 5 * time.Minute
+	defaultSapSystemStateInterval     = 10 * time.Second
+	defaultSapSystemStateInstanceType = sapcontrol.StartStopOptionSAPControlALLINSTANCES
+
+	instanceTypeALL    = "all"
+	instanceTypeABAP   = "abap"
+	instanceTypeJ2EE   = "j2ee"
+	instanceTypeSCS    = "scs"
+	instanceTypeENQREP = "enqrep"
+)
+
+type sapSystemStartDiffOutput struct {
+	Started bool `json:"started"`
+}
+
+type sapSystemStateChangeArguments struct {
+	instNumber   string
+	timeout      time.Duration
+	instanceType sapcontrol.StartStopOption
+}
+
+type SAPSystemStartOption Option[SAPSystemStart]
+
+// SAPSystemStart operator starts a SAP system.
+//
+// Arguments:
+//  instance_number (required): String with the instance number of local instance to start the whole system
+//  timeout: Timeout in seconds to wait until the system is started
+//  instance_type: Instance type to filter in the StartSystem process. Values: all|abap|j2ee|scs|enqrep. Default value: all
+//
+// # Execution Phases
+//
+// - PLAN:
+//   The operator gets the system current instances and stores the state.
+//   The operation is skipped if the SAP system is already started.
+//
+// - COMMIT:
+//   It starts the SAP system using the sapcontrol StartSystem command.
+//
+// - VERIFY:
+//   Verify if the SAP system is started.
+//
+// - ROLLBACK:
+//   If an error occurs during the COMMIT or VERIFY phase, the system is stopped back again.
+
+type SAPSystemStart struct {
+	baseOperator
+	parsedArguments     *sapSystemStateChangeArguments
+	sapControlConnector sapcontrol.SAPControlConnector
+	interval            time.Duration
+}
+
+func WithCustomStartSystemSapcontrol(sapControlConnector sapcontrol.SAPControlConnector) SAPSystemStartOption {
+	return func(o *SAPSystemStart) {
+		o.sapControlConnector = sapControlConnector
+	}
+}
+
+func WithCustomStartSystemInterval(interval time.Duration) SAPSystemStartOption {
+	return func(o *SAPSystemStart) {
+		o.interval = interval
+	}
+}
+
+func NewSAPSystemStart(
+	arguments OperatorArguments,
+	operationID string,
+	options OperatorOptions[SAPSystemStart],
+) *Executor {
+	sapSystemStart := &SAPSystemStart{
+		baseOperator: newBaseOperator(operationID, arguments, options.BaseOperatorOptions...),
+		interval:     defaultSapSystemStateInterval,
+	}
+
+	for _, opt := range options.OperatorOptions {
+		opt(sapSystemStart)
+	}
+
+	return &Executor{
+		phaser:      sapSystemStart,
+		operationID: operationID,
+	}
+}
+
+func (s *SAPSystemStart) plan(ctx context.Context) (bool, error) {
+	opArguments, err := parseSAPSystemStateChangeArguments(s.arguments)
+	if err != nil {
+		return false, err
+	}
+	s.parsedArguments = opArguments
+
+	// Use custom sapControlConnector or create a new one based on the instance_number argument
+	if s.sapControlConnector == nil {
+		s.sapControlConnector = sapcontrol.NewSAPControlConnector(s.parsedArguments.instNumber)
+	}
+
+	started, err := allInstancesInState(
+		ctx,
+		s.sapControlConnector,
+		s.parsedArguments.instanceType,
+		sapcontrol.STATECOLORSAPControlGREEN,
+	)
+	if err != nil {
+		return false, fmt.Errorf("error checking system state: %w", err)
+	}
+
+	s.resources[beforeDiffField] = started
+
+	if started {
+		s.logger.Info("system already started, skipping operation")
+		s.resources[afterDiffField] = started
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (s *SAPSystemStart) commit(ctx context.Context) error {
+	request := new(sapcontrol.StartSystem)
+	request.Options = &s.parsedArguments.instanceType
+	_, err := s.sapControlConnector.StartSystemContext(ctx, request)
+	if err != nil {
+		return fmt.Errorf("error starting system: %w", err)
+	}
+
+	return nil
+}
+
+func (s *SAPSystemStart) verify(ctx context.Context) error {
+	err := waitUntilSapSystemState(
+		ctx,
+		s.sapControlConnector,
+		s.parsedArguments.instanceType,
+		sapcontrol.STATECOLORSAPControlGREEN,
+		s.parsedArguments.timeout,
+		s.interval,
+	)
+
+	if err != nil {
+		return fmt.Errorf("verify system started failed: %w", err)
+	}
+
+	s.resources[afterDiffField] = true
+	return nil
+}
+
+func (s *SAPSystemStart) rollback(ctx context.Context) error {
+	request := new(sapcontrol.StopSystem)
+	request.Options = &s.parsedArguments.instanceType
+	_, err := s.sapControlConnector.StopSystemContext(ctx, request)
+	if err != nil {
+		return fmt.Errorf("error stopping system: %w", err)
+	}
+
+	err = waitUntilSapSystemState(
+		ctx,
+		s.sapControlConnector,
+		s.parsedArguments.instanceType,
+		sapcontrol.STATECOLORSAPControlGRAY,
+		s.parsedArguments.timeout,
+		s.interval,
+	)
+
+	if err != nil {
+		return fmt.Errorf("rollback to stopped failed: %w", err)
+	}
+
+	return nil
+}
+
+func (s *SAPSystemStart) operationDiff(ctx context.Context) map[string]any {
+	diff := make(map[string]any)
+
+	beforeDiffOutput := sapSystemStartDiffOutput{
+		Started: s.resources[beforeDiffField].(bool),
+	}
+	before, _ := json.Marshal(beforeDiffOutput)
+	diff["before"] = string(before)
+
+	afterDiffOutput := sapSystemStartDiffOutput{
+		Started: s.resources[afterDiffField].(bool),
+	}
+	after, _ := json.Marshal(afterDiffOutput)
+	diff["after"] = string(after)
+
+	return diff
+}
+
+func allInstancesInState(
+	ctx context.Context,
+	connector sapcontrol.SAPControlConnector,
+	instanceType sapcontrol.StartStopOption,
+	expectedState sapcontrol.STATECOLOR,
+) (bool, error) {
+	request := new(sapcontrol.GetSystemInstanceList)
+	response, err := connector.GetSystemInstanceListContext(ctx, request)
+	if err != nil {
+		return false, fmt.Errorf("error getting instance list: %w", err)
+	}
+
+	filteringMap := map[sapcontrol.StartStopOption]string{
+		sapcontrol.StartStopOptionSAPControlALLINSTANCES:    "",
+		sapcontrol.StartStopOptionSAPControlABAPINSTANCES:   "ABAP",
+		sapcontrol.StartStopOptionSAPControlJ2EEINSTANCES:   "J2EE",
+		sapcontrol.StartStopOptionSAPControlSCSINSTANCES:    "MESSAGESERVER",
+		sapcontrol.StartStopOptionSAPControlENQREPINSTANCES: "ENQREP",
+	}
+	filteringValue := filteringMap[instanceType]
+
+	for _, instance := range response.Instances {
+		// filter out instances that are not part of the current instance type value
+		if !strings.Contains(instance.Features, filteringValue) {
+			continue
+		}
+
+		if *instance.Dispstatus != expectedState {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func waitUntilSapSystemState(
+	ctx context.Context,
+	connector sapcontrol.SAPControlConnector,
+	instanceType sapcontrol.StartStopOption,
+	expectedState sapcontrol.STATECOLOR,
+	timeout time.Duration,
+	interval time.Duration,
+) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	for {
+		inState, err := allInstancesInState(timeoutCtx, connector, instanceType, expectedState)
+		if err != nil {
+			return err
+		}
+
+		if timeoutCtx.Err() != nil {
+			return fmt.Errorf("error waiting until system is in desired state")
+		}
+
+		if inState {
+			return nil
+		}
+
+		err = sleepContext(timeoutCtx, interval)
+		if err != nil {
+			return err
+		}
+	}
+
+}
+
+func parseSAPSystemStateChangeArguments(rawArguments OperatorArguments) (*sapSystemStateChangeArguments, error) {
+	instNumberArgument, found := rawArguments["instance_number"]
+	if !found {
+		return nil, fmt.Errorf("argument instance_number not provided, could not use the operator")
+	}
+
+	instNumber, ok := instNumberArgument.(string)
+	if !ok {
+		return nil, fmt.Errorf(
+			"could not parse instance_number argument as string, argument provided: %v",
+			instNumberArgument,
+		)
+	}
+
+	timeout := defaultSapSystemStateTimeout
+	if timeoutArgument, found := rawArguments["timeout"]; found {
+		timeoutFloat, ok := timeoutArgument.(float64)
+		if !ok {
+			return nil, fmt.Errorf(
+				"could not parse timeout argument as a number, argument provided: %v",
+				timeoutArgument,
+			)
+		}
+
+		timeout = time.Duration(timeoutFloat) * time.Second
+	}
+
+	instanceType := defaultSapSystemStateInstanceType
+	if instanceTypeArgument, found := rawArguments["instance_type"]; found {
+		instanceTypeStr, ok := instanceTypeArgument.(string)
+		if !ok {
+			return nil, fmt.Errorf(
+				"could not parse instance_type argument as a string, argument provided: %v",
+				instanceTypeArgument,
+			)
+		}
+
+		instancesMap := map[string]sapcontrol.StartStopOption{
+			instanceTypeALL:    sapcontrol.StartStopOptionSAPControlALLINSTANCES,
+			instanceTypeABAP:   sapcontrol.StartStopOptionSAPControlABAPINSTANCES,
+			instanceTypeJ2EE:   sapcontrol.StartStopOptionSAPControlJ2EEINSTANCES,
+			instanceTypeSCS:    sapcontrol.StartStopOptionSAPControlSCSINSTANCES,
+			instanceTypeENQREP: sapcontrol.StartStopOptionSAPControlENQREPINSTANCES,
+		}
+		instanceType, ok = instancesMap[instanceTypeStr]
+		if !ok {
+			return nil, fmt.Errorf("invalid instance_type value: %s", instanceTypeStr)
+		}
+	}
+
+	return &sapSystemStateChangeArguments{
+		instNumber:   instNumber,
+		timeout:      timeout,
+		instanceType: instanceType,
+	}, nil
+}

--- a/pkg/operator/sapsystemstart_v1_test.go
+++ b/pkg/operator/sapsystemstart_v1_test.go
@@ -1,0 +1,650 @@
+package operator_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/workbench/internal/sapcontrol"
+	"github.com/trento-project/workbench/internal/sapcontrol/mocks"
+	"github.com/trento-project/workbench/pkg/operator"
+)
+
+type SAPSystemStartOperatorTestSuite struct {
+	suite.Suite
+	mockSapcontrol *mocks.MockSAPControlConnector
+}
+
+func TestSAPSystemStartOperator(t *testing.T) {
+	suite.Run(t, new(SAPSystemStartOperatorTestSuite))
+}
+
+func (suite *SAPSystemStartOperatorTestSuite) SetupTest() {
+	suite.mockSapcontrol = mocks.NewMockSAPControlConnector(suite.T())
+}
+
+func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartInstanceNumberMissing() {
+	ctx := context.Background()
+
+	sapSystemStartOperator := operator.NewSAPSystemStart(
+		operator.OperatorArguments{},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStart]{},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("argument instance_number not provided, could not use the operator", report.Error.Message)
+}
+
+func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartInstanceNumberInvalid() {
+	ctx := context.Background()
+
+	sapSystemStartOperator := operator.NewSAPSystemStart(
+		operator.OperatorArguments{
+			"instance_number": 0,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStart]{},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("could not parse instance_number argument as string, argument provided: 0", report.Error.Message)
+}
+
+func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartTimeoutInvalid() {
+	ctx := context.Background()
+
+	sapSystemStartOperator := operator.NewSAPSystemStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"timeout":         "value",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStart]{},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("could not parse timeout argument as a number, argument provided: value", report.Error.Message)
+}
+
+func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartInstanceTypeInvalid() {
+	ctx := context.Background()
+
+	sapSystemStartOperator := operator.NewSAPSystemStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"instance_type":   0,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStart]{},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("could not parse instance_type argument as a string, argument provided: 0", report.Error.Message)
+}
+
+func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartInstanceTypeUnknown() {
+	ctx := context.Background()
+
+	sapSystemStartOperator := operator.NewSAPSystemStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"instance_type":   "unknown",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStart]{},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("invalid instance_type value: unknown", report.Error.Message)
+}
+
+func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartPlanError() {
+	ctx := context.Background()
+
+	suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", ctx, mock.Anything).
+		Return(nil, errors.New("error getting instances")).
+		Once()
+
+	sapSystemStartOperator := operator.NewSAPSystemStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"timeout":         300.0,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStart]{
+			OperatorOptions: []operator.Option[operator.SAPSystemStart]{
+				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("error checking system state: error getting instance list: error getting instances", report.Error.Message)
+}
+
+func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartCommitAlreadyStarted() {
+	ctx := context.Background()
+
+	green := sapcontrol.STATECOLORSAPControlGREEN
+
+	suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+		Return(&sapcontrol.GetSystemInstanceListResponse{
+			Instances: []*sapcontrol.SAPInstance{
+				{
+					Dispstatus: &green,
+				},
+				{
+					Dispstatus: &green,
+				},
+			},
+		}, nil).
+		Once()
+
+	sapSystemStartOperator := operator.NewSAPSystemStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStart]{
+			OperatorOptions: []operator.Option[operator.SAPSystemStart]{
+				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	expectedDiff := map[string]any{
+		"before": `{"started":true}`,
+		"after":  `{"started":true}`,
+	}
+
+	suite.Nil(report.Error)
+	suite.Equal(operator.PLAN, report.Success.LastPhase)
+	suite.EqualValues(expectedDiff, report.Success.Diff)
+}
+
+func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartCommitAlreadyStartedFiltered() {
+	cases := []struct {
+		instanceType string
+		features     string
+	}{
+		{
+			instanceType: "abap",
+			features:     "ABAP|GATEWAY|ICMAN|IGS",
+		},
+		{
+			instanceType: "j2ee",
+			features:     "J2EE|IGS",
+		},
+		{
+			instanceType: "scs",
+			features:     "MESSAGESERVER|ENQUE",
+		},
+		{
+			instanceType: "enqrep",
+			features:     "ENQREP",
+		},
+	}
+
+	for _, tt := range cases {
+		ctx := context.Background()
+		suite.mockSapcontrol = mocks.NewMockSAPControlConnector(suite.T())
+
+		green := sapcontrol.STATECOLORSAPControlGREEN
+		gray := sapcontrol.STATECOLORSAPControlGRAY
+
+		suite.mockSapcontrol.
+			On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+			Return(&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Features:   "Other",
+						Dispstatus: &gray,
+					},
+					{
+						Features:   tt.features,
+						Dispstatus: &green,
+					},
+				},
+			}, nil).
+			Once()
+
+		sapSystemStartOperator := operator.NewSAPSystemStart(
+			operator.OperatorArguments{
+				"instance_number": "00",
+				"instance_type":   tt.instanceType,
+			},
+			"test-op",
+			operator.OperatorOptions[operator.SAPSystemStart]{
+				OperatorOptions: []operator.Option[operator.SAPSystemStart]{
+					operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
+				},
+			},
+		)
+
+		report := sapSystemStartOperator.Run(ctx)
+
+		expectedDiff := map[string]any{
+			"before": `{"started":true}`,
+			"after":  `{"started":true}`,
+		}
+
+		suite.Nil(report.Error)
+		suite.Equal(operator.PLAN, report.Success.LastPhase)
+		suite.EqualValues(expectedDiff, report.Success.Diff)
+	}
+}
+
+func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartCommitStartingError() {
+	ctx := context.Background()
+
+	gray := sapcontrol.STATECOLORSAPControlGRAY
+
+	planGetInstances := suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", ctx, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &gray,
+					},
+				},
+			}, nil,
+		).
+		Once()
+
+	suite.mockSapcontrol.
+		On("StartSystemContext", ctx, mock.Anything).
+		Return(nil, errors.New("error starting")).
+		NotBefore(planGetInstances).
+		On("StopSystemContext", ctx, mock.Anything).
+		Return(nil, nil).
+		NotBefore(planGetInstances).
+		On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &gray,
+					},
+				},
+			}, nil,
+		).
+		Once().
+		NotBefore(planGetInstances)
+
+	sapSystemStartOperator := operator.NewSAPSystemStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStart]{
+			OperatorOptions: []operator.Option[operator.SAPSystemStart]{
+				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.COMMIT, report.Error.ErrorPhase)
+	suite.EqualValues("error starting system: error starting", report.Error.Message)
+}
+
+func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartVerifyError() {
+	ctx := context.Background()
+
+	gray := sapcontrol.STATECOLORSAPControlGRAY
+
+	planGetInstances := suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", ctx, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &gray,
+					},
+				},
+			}, nil,
+		).
+		Once()
+
+	verifyGetInstances := suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+		Return(nil, errors.New("error getting instances in verify")).
+		Once().
+		NotBefore(planGetInstances)
+
+	suite.mockSapcontrol.
+		On("StartSystemContext", ctx, mock.Anything).
+		Return(nil, nil).
+		NotBefore(planGetInstances).
+		On("StopSystemContext", ctx, mock.Anything).
+		Return(nil, nil).
+		NotBefore(verifyGetInstances).
+		On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &gray,
+					},
+				},
+			}, nil,
+		).
+		NotBefore(verifyGetInstances)
+
+	sapSystemStartOperator := operator.NewSAPSystemStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStart]{
+			OperatorOptions: []operator.Option[operator.SAPSystemStart]{
+				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.VERIFY, report.Error.ErrorPhase)
+	suite.EqualValues("verify system started failed: error getting instance list: error getting instances in verify", report.Error.Message)
+}
+
+func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartVerifyTimeout() {
+	ctx := context.Background()
+
+	gray := sapcontrol.STATECOLORSAPControlGRAY
+
+	suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &gray,
+					},
+				},
+			}, nil,
+		).
+		Times(3).
+		On("StartSystemContext", ctx, mock.Anything).
+		Return(nil, nil).
+		On("StopSystemContext", ctx, mock.Anything).
+		Return(nil, nil)
+
+	sapSystemStartOperator := operator.NewSAPSystemStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"timeout":         0.0,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStart]{
+			OperatorOptions: []operator.Option[operator.SAPSystemStart]{
+				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
+				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemInterval(0 * time.Second)),
+			},
+		},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
+	suite.EqualValues(
+		"rollback to stopped failed: error waiting until system is in desired state\n"+
+			"verify system started failed: "+
+			"error waiting until system is in desired state", report.Error.Message)
+}
+
+func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartRollbackStoppingError() {
+	ctx := context.Background()
+
+	gray := sapcontrol.STATECOLORSAPControlGRAY
+
+	suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", ctx, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &gray,
+						Features:   "ABAP|GATEWAY|ICMAN|IGS",
+					},
+				},
+			}, nil,
+		).
+		Once().
+		On("StartSystemContext", ctx, mock.Anything).
+		Return(nil, errors.New("error starting")).
+		On(
+			"StopSystemContext",
+			ctx,
+			mock.MatchedBy(func(req *sapcontrol.StopSystem) bool {
+				return *req.Options == sapcontrol.StartStopOptionSAPControlABAPINSTANCES
+			}),
+		).
+		Return(nil, errors.New("error stopping"))
+
+	sapSystemStartOperator := operator.NewSAPSystemStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"instance_type":   "abap",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStart]{
+			OperatorOptions: []operator.Option[operator.SAPSystemStart]{
+				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
+	suite.EqualValues("error stopping system: error stopping\nerror starting system: error starting", report.Error.Message)
+}
+
+func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartSuccess() {
+	cases := []struct {
+		instanceType string
+		features     string
+		options      sapcontrol.StartStopOption
+	}{
+		{
+			instanceType: "all",
+			features:     "OTHER",
+			options:      sapcontrol.StartStopOptionSAPControlALLINSTANCES,
+		},
+		{
+			instanceType: "abap",
+			features:     "ABAP|GATEWAY|ICMAN|IGS",
+			options:      sapcontrol.StartStopOptionSAPControlABAPINSTANCES,
+		},
+		{
+			instanceType: "j2ee",
+			features:     "J2EE|IGS",
+			options:      sapcontrol.StartStopOptionSAPControlJ2EEINSTANCES,
+		},
+		{
+			instanceType: "scs",
+			features:     "MESSAGESERVER|ENQUE",
+			options:      sapcontrol.StartStopOptionSAPControlSCSINSTANCES,
+		},
+		{
+			instanceType: "enqrep",
+			features:     "ENQREP",
+			options:      sapcontrol.StartStopOptionSAPControlENQREPINSTANCES,
+		},
+	}
+
+	for _, tt := range cases {
+		ctx := context.Background()
+		suite.mockSapcontrol = mocks.NewMockSAPControlConnector(suite.T())
+
+		green := sapcontrol.STATECOLORSAPControlGREEN
+		gray := sapcontrol.STATECOLORSAPControlGRAY
+
+		planGetInstances := suite.mockSapcontrol.
+			On("GetSystemInstanceListContext", ctx, mock.Anything).
+			Return(&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &gray,
+						Features:   tt.features,
+					},
+				},
+			}, nil).
+			Once()
+
+		suite.mockSapcontrol.
+			On(
+				"StartSystemContext",
+				ctx,
+				mock.MatchedBy(func(req *sapcontrol.StartSystem) bool {
+					return *req.Options == tt.options
+				}),
+			).
+			Return(nil, nil).
+			NotBefore(planGetInstances).
+			On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+			Return(&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &green,
+						Features:   tt.features,
+					},
+				},
+			}, nil).
+			Once().
+			NotBefore(planGetInstances)
+
+		sapSystemStartOperator := operator.NewSAPSystemStart(
+			operator.OperatorArguments{
+				"instance_number": "00",
+				"instance_type":   tt.instanceType,
+			},
+			"test-op",
+			operator.OperatorOptions[operator.SAPSystemStart]{
+				OperatorOptions: []operator.Option[operator.SAPSystemStart]{
+					operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
+				},
+			},
+		)
+
+		report := sapSystemStartOperator.Run(ctx)
+
+		expectedDiff := map[string]any{
+			"before": `{"started":false}`,
+			"after":  `{"started":true}`,
+		}
+
+		suite.Nil(report.Error)
+		suite.Equal(operator.VERIFY, report.Success.LastPhase)
+		suite.EqualValues(expectedDiff, report.Success.Diff)
+	}
+}
+
+func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartSuccessMultipleQueries() {
+	ctx := context.Background()
+
+	gray := sapcontrol.STATECOLORSAPControlGRAY
+	green := sapcontrol.STATECOLORSAPControlGREEN
+
+	planGetInstances := suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", ctx, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &gray,
+					},
+				},
+			}, nil,
+		).
+		Once()
+
+	suite.mockSapcontrol.
+		On("StartSystemContext", ctx, mock.Anything).
+		Return(nil, nil).
+		NotBefore(planGetInstances)
+
+	suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &gray,
+					},
+				},
+			}, nil,
+		).
+		Times(3).
+		NotBefore(planGetInstances).
+		On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &green,
+					},
+				},
+			}, nil,
+		).
+		Once()
+
+	sapSystemStartOperator := operator.NewSAPSystemStart(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"timeout":         5.0,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStart]{
+			OperatorOptions: []operator.Option[operator.SAPSystemStart]{
+				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
+				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemInterval(0 * time.Second)),
+			},
+		},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	expectedDiff := map[string]any{
+		"before": `{"started":false}`,
+		"after":  `{"started":true}`,
+	}
+
+	suite.Nil(report.Error)
+	suite.Equal(operator.VERIFY, report.Success.LastPhase)
+	suite.EqualValues(expectedDiff, report.Success.Diff)
+}


### PR DESCRIPTION
# Description

Add SAP system start operator.
It uses the `StartSystem` sapcontrol method to start the system, and the instances are monitored using the `GetSystemInstanceList` method.
The start method can optionally get a `instance_type` value which is used to filter in the instances that will be started during the operation. I have only included some few of them: `all/abap/j2ee/scs/enqrep`. 

Besides this, it follows the exact same strategy that we use for instance operations.

## How was this tested?

UT and I have done some testing in real deployments
