### PR TITLE
Add SAP system stop operator

### DIFF
--- a/pkg/operator/registry.go
+++ b/pkg/operator/registry.go
@@ -127,6 +127,13 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 					})
 				},
 			},
+			SapSystemStopOperatorName: map[string]OperatorBuilder{
+				"v1": func(operationID string, arguments OperatorArguments) Operator {
+					return NewSAPSystemStop(arguments, operationID, OperatorOptions[SAPSystemStop]{
+						BaseOperatorOptions: options,
+					})
+				},
+			},
 			SaptuneApplySolutionOperatorName: map[string]OperatorBuilder{
 				"v1": func(operationID string, arguments OperatorArguments) Operator {
 					return NewSaptuneApplySolution(arguments, operationID, OperatorOptions[SaptuneApplySolution]{

--- a/pkg/operator/sapsystemstop_v1.go
+++ b/pkg/operator/sapsystemstop_v1.go
@@ -1,0 +1,185 @@
+package operator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/trento-project/workbench/internal/sapcontrol"
+)
+
+const (
+	SapSystemStopOperatorName = "sapsystemstop"
+)
+
+type sapSystemStopDiffOutput struct {
+	Stopped bool `json:"stopped"`
+}
+
+type SAPSystemStopOption Option[SAPSystemStop]
+
+// SAPSystemStop operator stops a SAP system.
+//
+// Arguments:
+//  instance_number (required): String with the instance number of local instance to stop the whole system
+//  timeout: Timeout in seconds to wait until the system is stopped
+//  instance_type: Instance type to filter in the StopSystem process. Values: all|abap|j2ee|scs|enqrep. Default value: all
+//
+// # Execution Phases
+//
+// - PLAN:
+//   The operator gets the system current instances and stores the state.
+//   The operation is skipped if the SAP system is already stopped.
+//
+// - COMMIT:
+//   It stops the SAP system using the sapcontrol StopSystem command.
+//
+// - VERIFY:
+//   Verify if the SAP system is stopped.
+//
+// - ROLLBACK:
+//   If an error occurs during the COMMIT or VERIFY phase, the system is started back again.
+
+type SAPSystemStop struct {
+	baseOperator
+	parsedArguments     *sapSystemStateChangeArguments
+	sapControlConnector sapcontrol.SAPControlConnector
+	interval            time.Duration
+}
+
+func WithCustomStopSystemSapcontrol(sapControlConnector sapcontrol.SAPControlConnector) SAPSystemStopOption {
+	return func(o *SAPSystemStop) {
+		o.sapControlConnector = sapControlConnector
+	}
+}
+
+func WithCustomStopSystemInterval(interval time.Duration) SAPSystemStopOption {
+	return func(o *SAPSystemStop) {
+		o.interval = interval
+	}
+}
+
+func NewSAPSystemStop(
+	arguments OperatorArguments,
+	operationID string,
+	options OperatorOptions[SAPSystemStop],
+) *Executor {
+	sapSystemStop := &SAPSystemStop{
+		baseOperator: newBaseOperator(operationID, arguments, options.BaseOperatorOptions...),
+		interval:     defaultSapSystemStateInterval,
+	}
+
+	for _, opt := range options.OperatorOptions {
+		opt(sapSystemStop)
+	}
+
+	return &Executor{
+		phaser:      sapSystemStop,
+		operationID: operationID,
+	}
+}
+
+func (s *SAPSystemStop) plan(ctx context.Context) (bool, error) {
+	opArguments, err := parseSAPSystemStateChangeArguments(s.arguments)
+	if err != nil {
+		return false, err
+	}
+	s.parsedArguments = opArguments
+
+	// Use custom sapControlConnector or create a new one based on the instance_number argument
+	if s.sapControlConnector == nil {
+		s.sapControlConnector = sapcontrol.NewSAPControlConnector(s.parsedArguments.instNumber)
+	}
+
+	stopped, err := allInstancesInState(
+		ctx,
+		s.sapControlConnector,
+		s.parsedArguments.instanceType,
+		sapcontrol.STATECOLORSAPControlGRAY,
+	)
+	if err != nil {
+		return false, fmt.Errorf("error checking system state: %w", err)
+	}
+
+	s.resources[beforeDiffField] = stopped
+
+	if stopped {
+		s.logger.Info("system already stopped, skipping operation")
+		s.resources[afterDiffField] = stopped
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (s *SAPSystemStop) commit(ctx context.Context) error {
+	request := new(sapcontrol.StopSystem)
+	request.Options = &s.parsedArguments.instanceType
+	_, err := s.sapControlConnector.StopSystemContext(ctx, request)
+	if err != nil {
+		return fmt.Errorf("error stopping system: %w", err)
+	}
+
+	return nil
+}
+
+func (s *SAPSystemStop) verify(ctx context.Context) error {
+	err := waitUntilSapSystemState(
+		ctx,
+		s.sapControlConnector,
+		s.parsedArguments.instanceType,
+		sapcontrol.STATECOLORSAPControlGRAY,
+		s.parsedArguments.timeout,
+		s.interval,
+	)
+
+	if err != nil {
+		return fmt.Errorf("verify system stopped failed: %w", err)
+	}
+
+	s.resources[afterDiffField] = true
+	return nil
+}
+
+func (s *SAPSystemStop) rollback(ctx context.Context) error {
+	request := new(sapcontrol.StartSystem)
+	request.Options = &s.parsedArguments.instanceType
+	_, err := s.sapControlConnector.StartSystemContext(ctx, request)
+	if err != nil {
+		return fmt.Errorf("error starting system: %w", err)
+	}
+
+	err = waitUntilSapSystemState(
+		ctx,
+		s.sapControlConnector,
+		s.parsedArguments.instanceType,
+		sapcontrol.STATECOLORSAPControlGREEN,
+		s.parsedArguments.timeout,
+		s.interval,
+	)
+
+	if err != nil {
+		return fmt.Errorf("rollback to started failed: %w", err)
+	}
+
+	return nil
+}
+
+func (s *SAPSystemStop) operationDiff(ctx context.Context) map[string]any {
+	diff := make(map[string]any)
+
+	beforeDiffOutput := sapSystemStopDiffOutput{
+		Stopped: s.resources[beforeDiffField].(bool),
+	}
+	before, _ := json.Marshal(beforeDiffOutput)
+	diff["before"] = string(before)
+
+	afterDiffOutput := sapSystemStopDiffOutput{
+		Stopped: s.resources[afterDiffField].(bool),
+	}
+	after, _ := json.Marshal(afterDiffOutput)
+	diff["after"] = string(after)
+
+	return diff
+}

--- a/pkg/operator/sapsystemstop_v1_test.go
+++ b/pkg/operator/sapsystemstop_v1_test.go
@@ -1,0 +1,661 @@
+package operator_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/workbench/internal/sapcontrol"
+	"github.com/trento-project/workbench/internal/sapcontrol/mocks"
+	"github.com/trento-project/workbench/pkg/operator"
+)
+
+type SAPSystemStopOperatorTestSuite struct {
+	suite.Suite
+	mockSapcontrol *mocks.MockSAPControlConnector
+}
+
+func TestSAPSystemStopOperator(t *testing.T) {
+	suite.Run(t, new(SAPSystemStopOperatorTestSuite))
+}
+
+func (suite *SAPSystemStopOperatorTestSuite) SetupTest() {
+	suite.mockSapcontrol = mocks.NewMockSAPControlConnector(suite.T())
+}
+
+func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceNumberMissing() {
+	ctx := context.Background()
+
+	sapSystemStartOperator := operator.NewSAPSystemStop(
+		operator.OperatorArguments{},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStop]{},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("argument instance_number not provided, could not use the operator", report.Error.Message)
+}
+
+func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceNumberInvalid() {
+	ctx := context.Background()
+
+	sapSystemStartOperator := operator.NewSAPSystemStop(
+		operator.OperatorArguments{
+			"instance_number": 0,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStop]{},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("could not parse instance_number argument as string, argument provided: 0", report.Error.Message)
+}
+
+func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopTimeoutInvalid() {
+	ctx := context.Background()
+
+	sapSystemStartOperator := operator.NewSAPSystemStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"timeout":         "value",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStop]{},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("could not parse timeout argument as a number, argument provided: value", report.Error.Message)
+}
+
+func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceTypeInvalid() {
+	ctx := context.Background()
+
+	sapSystemStartOperator := operator.NewSAPSystemStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"instance_type":   0,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStop]{},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("could not parse instance_type argument as a string, argument provided: 0", report.Error.Message)
+}
+
+func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceTypeUnknown() {
+	ctx := context.Background()
+
+	sapSystemStartOperator := operator.NewSAPSystemStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"instance_type":   "unknown",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStop]{},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("invalid instance_type value: unknown", report.Error.Message)
+}
+
+func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopPlanError() {
+	ctx := context.Background()
+
+	suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", ctx, mock.Anything).
+		Return(nil, errors.New("error getting instances")).
+		Once()
+
+	sapSystemStartOperator := operator.NewSAPSystemStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"timeout":         300.0,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStop]{
+			OperatorOptions: []operator.Option[operator.SAPSystemStop]{
+				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
+	suite.EqualValues("error checking system state: error getting instance list: error getting instances", report.Error.Message)
+}
+
+func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopCommitAlreadyStopped() {
+	ctx := context.Background()
+
+	gray := sapcontrol.STATECOLORSAPControlGRAY
+
+	suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+		Return(&sapcontrol.GetSystemInstanceListResponse{
+			Instances: []*sapcontrol.SAPInstance{
+				{
+					Dispstatus: &gray,
+				},
+				{
+					Dispstatus: &gray,
+				},
+			},
+		}, nil).
+		Once()
+
+	sapSystemStartOperator := operator.NewSAPSystemStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStop]{
+			OperatorOptions: []operator.Option[operator.SAPSystemStop]{
+				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	expectedDiff := map[string]any{
+		"before": `{"stopped":true}`,
+		"after":  `{"stopped":true}`,
+	}
+
+	suite.Nil(report.Error)
+	suite.Equal(operator.PLAN, report.Success.LastPhase)
+	suite.EqualValues(expectedDiff, report.Success.Diff)
+}
+
+func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopCommitAlreadyStoppedFiltered() {
+	cases := []struct {
+		instanceType string
+		features     string
+	}{
+		{
+			instanceType: "abap",
+			features:     "ABAP|GATEWAY|ICMAN|IGS",
+		},
+		{
+			instanceType: "j2ee",
+			features:     "J2EE|IGS",
+		},
+		{
+			instanceType: "scs",
+			features:     "MESSAGESERVER|ENQUE",
+		},
+		{
+			instanceType: "enqrep",
+			features:     "ENQREP",
+		},
+	}
+
+	for _, tt := range cases {
+		ctx := context.Background()
+		suite.mockSapcontrol = mocks.NewMockSAPControlConnector(suite.T())
+
+		green := sapcontrol.STATECOLORSAPControlGREEN
+		gray := sapcontrol.STATECOLORSAPControlGRAY
+
+		suite.mockSapcontrol.
+			On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+			Return(&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Features:   "Other",
+						Dispstatus: &green,
+					},
+					{
+						Features:   tt.features,
+						Dispstatus: &gray,
+					},
+				},
+			}, nil).
+			Once()
+
+		sapSystemStartOperator := operator.NewSAPSystemStop(
+			operator.OperatorArguments{
+				"instance_number": "00",
+				"instance_type":   tt.instanceType,
+			},
+			"test-op",
+			operator.OperatorOptions[operator.SAPSystemStop]{
+				OperatorOptions: []operator.Option[operator.SAPSystemStop]{
+					operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
+				},
+			},
+		)
+
+		report := sapSystemStartOperator.Run(ctx)
+
+		expectedDiff := map[string]any{
+			"before": `{"stopped":true}`,
+			"after":  `{"stopped":true}`,
+		}
+
+		suite.Nil(report.Error)
+		suite.Equal(operator.PLAN, report.Success.LastPhase)
+		suite.EqualValues(expectedDiff, report.Success.Diff)
+	}
+}
+
+func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopCommitStoppingError() {
+	ctx := context.Background()
+
+	green := sapcontrol.STATECOLORSAPControlGREEN
+
+	planGetInstances := suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", ctx, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &green,
+					},
+				},
+			}, nil,
+		).
+		Once()
+
+	stopSystem := suite.mockSapcontrol.
+		On("StopSystemContext", ctx, mock.Anything).
+		Return(nil, errors.New("error stopping")).
+		NotBefore(planGetInstances)
+
+	rollbackStartSystem := suite.mockSapcontrol.
+		On("StartSystemContext", ctx, mock.Anything).
+		Return(nil, nil).
+		NotBefore(stopSystem)
+
+	suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &green,
+					},
+				},
+			}, nil,
+		).
+		Once().
+		NotBefore(rollbackStartSystem)
+
+	sapSystemStartOperator := operator.NewSAPSystemStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStop]{
+			OperatorOptions: []operator.Option[operator.SAPSystemStop]{
+				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.COMMIT, report.Error.ErrorPhase)
+	suite.EqualValues("error stopping system: error stopping", report.Error.Message)
+}
+
+func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopVerifyError() {
+	ctx := context.Background()
+
+	green := sapcontrol.STATECOLORSAPControlGREEN
+
+	planGetInstances := suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", ctx, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &green,
+					},
+				},
+			}, nil,
+		).
+		Once()
+
+	stopSystem := suite.mockSapcontrol.
+		On("StopSystemContext", ctx, mock.Anything).
+		Return(nil, nil).
+		NotBefore(planGetInstances)
+
+	verifyGetInstances := suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+		Return(nil, errors.New("error getting instances in verify")).
+		Once().
+		NotBefore(stopSystem)
+
+	rollbackStartSystem := suite.mockSapcontrol.
+		On("StartSystemContext", ctx, mock.Anything).
+		Return(nil, nil).
+		NotBefore(verifyGetInstances)
+
+	suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &green,
+					},
+				},
+			}, nil,
+		).
+		Once().
+		NotBefore(rollbackStartSystem)
+
+	sapSystemStartOperator := operator.NewSAPSystemStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStop]{
+			OperatorOptions: []operator.Option[operator.SAPSystemStop]{
+				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.VERIFY, report.Error.ErrorPhase)
+	suite.EqualValues("verify system stopped failed: error getting instance list: error getting instances in verify", report.Error.Message)
+}
+
+func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopVerifyTimeout() {
+	ctx := context.Background()
+
+	green := sapcontrol.STATECOLORSAPControlGREEN
+
+	suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &green,
+					},
+				},
+			}, nil,
+		).
+		Times(3).
+		On("StopSystemContext", ctx, mock.Anything).
+		Return(nil, nil).
+		On("StartSystemContext", ctx, mock.Anything).
+		Return(nil, nil)
+
+	sapSystemStartOperator := operator.NewSAPSystemStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"timeout":         0.0,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStop]{
+			OperatorOptions: []operator.Option[operator.SAPSystemStop]{
+				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
+				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemInterval(0 * time.Second)),
+			},
+		},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
+	suite.EqualValues(
+		"rollback to started failed: error waiting until system is in desired state\n"+
+			"verify system stopped failed: "+
+			"error waiting until system is in desired state", report.Error.Message)
+}
+
+func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopRollbackStoppingError() {
+	ctx := context.Background()
+
+	green := sapcontrol.STATECOLORSAPControlGREEN
+
+	suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", ctx, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &green,
+						Features:   "ABAP|GATEWAY|ICMAN|IGS",
+					},
+				},
+			}, nil,
+		).
+		Once().
+		On("StopSystemContext", ctx, mock.Anything).
+		Return(nil, errors.New("error stopping")).
+		On(
+			"StartSystemContext",
+			ctx,
+			mock.MatchedBy(func(req *sapcontrol.StartSystem) bool {
+				return *req.Options == sapcontrol.StartStopOptionSAPControlABAPINSTANCES
+			}),
+		).
+		Return(nil, errors.New("error starting"))
+
+	sapSystemStartOperator := operator.NewSAPSystemStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"instance_type":   "abap",
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStop]{
+			OperatorOptions: []operator.Option[operator.SAPSystemStop]{
+				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
+			},
+		},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	suite.Nil(report.Success)
+	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
+	suite.EqualValues("error starting system: error starting\nerror stopping system: error stopping", report.Error.Message)
+}
+
+func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopSuccess() {
+	cases := []struct {
+		instanceType string
+		features     string
+		options      sapcontrol.StartStopOption
+	}{
+		{
+			instanceType: "all",
+			features:     "OTHER",
+			options:      sapcontrol.StartStopOptionSAPControlALLINSTANCES,
+		},
+		{
+			instanceType: "abap",
+			features:     "ABAP|GATEWAY|ICMAN|IGS",
+			options:      sapcontrol.StartStopOptionSAPControlABAPINSTANCES,
+		},
+		{
+			instanceType: "j2ee",
+			features:     "J2EE|IGS",
+			options:      sapcontrol.StartStopOptionSAPControlJ2EEINSTANCES,
+		},
+		{
+			instanceType: "scs",
+			features:     "MESSAGESERVER|ENQUE",
+			options:      sapcontrol.StartStopOptionSAPControlSCSINSTANCES,
+		},
+		{
+			instanceType: "enqrep",
+			features:     "ENQREP",
+			options:      sapcontrol.StartStopOptionSAPControlENQREPINSTANCES,
+		},
+	}
+
+	for _, tt := range cases {
+		ctx := context.Background()
+		suite.mockSapcontrol = mocks.NewMockSAPControlConnector(suite.T())
+
+		green := sapcontrol.STATECOLORSAPControlGREEN
+		gray := sapcontrol.STATECOLORSAPControlGRAY
+
+		planGetInstances := suite.mockSapcontrol.
+			On("GetSystemInstanceListContext", ctx, mock.Anything).
+			Return(&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &green,
+						Features:   tt.features,
+					},
+				},
+			}, nil).
+			Once()
+
+		stopSystem := suite.mockSapcontrol.
+			On(
+				"StopSystemContext",
+				ctx,
+				mock.MatchedBy(func(req *sapcontrol.StopSystem) bool {
+					return *req.Options == tt.options
+				}),
+			).
+			Return(nil, nil).
+			NotBefore(planGetInstances)
+
+		suite.mockSapcontrol.
+			On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+			Return(&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &gray,
+						Features:   tt.features,
+					},
+				},
+			}, nil).
+			Once().
+			NotBefore(stopSystem)
+
+		sapSystemStartOperator := operator.NewSAPSystemStop(
+			operator.OperatorArguments{
+				"instance_number": "00",
+				"instance_type":   tt.instanceType,
+			},
+			"test-op",
+			operator.OperatorOptions[operator.SAPSystemStop]{
+				OperatorOptions: []operator.Option[operator.SAPSystemStop]{
+					operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
+				},
+			},
+		)
+
+		report := sapSystemStartOperator.Run(ctx)
+
+		expectedDiff := map[string]any{
+			"before": `{"stopped":false}`,
+			"after":  `{"stopped":true}`,
+		}
+
+		suite.Nil(report.Error)
+		suite.Equal(operator.VERIFY, report.Success.LastPhase)
+		suite.EqualValues(expectedDiff, report.Success.Diff)
+	}
+}
+
+func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopSuccessMultipleQueries() {
+	ctx := context.Background()
+
+	gray := sapcontrol.STATECOLORSAPControlGRAY
+	green := sapcontrol.STATECOLORSAPControlGREEN
+
+	planGetInstances := suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", ctx, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &green,
+					},
+				},
+			}, nil,
+		).
+		Once()
+
+	stopSystem := suite.mockSapcontrol.
+		On("StopSystemContext", ctx, mock.Anything).
+		Return(nil, nil).
+		NotBefore(planGetInstances)
+
+	suite.mockSapcontrol.
+		On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &green,
+					},
+				},
+			}, nil,
+		).
+		Times(3).
+		NotBefore(stopSystem).
+		On("GetSystemInstanceListContext", mock.Anything, mock.Anything).
+		Return(
+			&sapcontrol.GetSystemInstanceListResponse{
+				Instances: []*sapcontrol.SAPInstance{
+					{
+						Dispstatus: &gray,
+					},
+				},
+			}, nil,
+		).
+		Once()
+
+	sapSystemStartOperator := operator.NewSAPSystemStop(
+		operator.OperatorArguments{
+			"instance_number": "00",
+			"timeout":         5.0,
+		},
+		"test-op",
+		operator.OperatorOptions[operator.SAPSystemStop]{
+			OperatorOptions: []operator.Option[operator.SAPSystemStop]{
+				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
+				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemInterval(0 * time.Second)),
+			},
+		},
+	)
+
+	report := sapSystemStartOperator.Run(ctx)
+
+	expectedDiff := map[string]any{
+		"before": `{"stopped":false}`,
+		"after":  `{"stopped":true}`,
+	}
+
+	suite.Nil(report.Error)
+	suite.Equal(operator.VERIFY, report.Success.LastPhase)
+	suite.EqualValues(expectedDiff, report.Success.Diff)
+}

--- a/pkg/operator/sapsystemstop_v1_test.go
+++ b/pkg/operator/sapsystemstop_v1_test.go
@@ -29,13 +29,13 @@ func (suite *SAPSystemStopOperatorTestSuite) SetupTest() {
 func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceNumberMissing() {
 	ctx := context.Background()
 
-	sapSystemStartOperator := operator.NewSAPSystemStop(
+	sapSystemStopOperator := operator.NewSAPSystemStop(
 		operator.OperatorArguments{},
 		"test-op",
 		operator.OperatorOptions[operator.SAPSystemStop]{},
 	)
 
-	report := sapSystemStartOperator.Run(ctx)
+	report := sapSystemStopOperator.Run(ctx)
 
 	suite.Nil(report.Success)
 	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
@@ -45,7 +45,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceNumberMiss
 func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceNumberInvalid() {
 	ctx := context.Background()
 
-	sapSystemStartOperator := operator.NewSAPSystemStop(
+	sapSystemStopOperator := operator.NewSAPSystemStop(
 		operator.OperatorArguments{
 			"instance_number": 0,
 		},
@@ -53,7 +53,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceNumberInva
 		operator.OperatorOptions[operator.SAPSystemStop]{},
 	)
 
-	report := sapSystemStartOperator.Run(ctx)
+	report := sapSystemStopOperator.Run(ctx)
 
 	suite.Nil(report.Success)
 	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
@@ -63,7 +63,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceNumberInva
 func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopTimeoutInvalid() {
 	ctx := context.Background()
 
-	sapSystemStartOperator := operator.NewSAPSystemStop(
+	sapSystemStopOperator := operator.NewSAPSystemStop(
 		operator.OperatorArguments{
 			"instance_number": "00",
 			"timeout":         "value",
@@ -72,7 +72,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopTimeoutInvalid() {
 		operator.OperatorOptions[operator.SAPSystemStop]{},
 	)
 
-	report := sapSystemStartOperator.Run(ctx)
+	report := sapSystemStopOperator.Run(ctx)
 
 	suite.Nil(report.Success)
 	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
@@ -82,7 +82,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopTimeoutInvalid() {
 func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceTypeInvalid() {
 	ctx := context.Background()
 
-	sapSystemStartOperator := operator.NewSAPSystemStop(
+	sapSystemStopOperator := operator.NewSAPSystemStop(
 		operator.OperatorArguments{
 			"instance_number": "00",
 			"instance_type":   0,
@@ -91,7 +91,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceTypeInvali
 		operator.OperatorOptions[operator.SAPSystemStop]{},
 	)
 
-	report := sapSystemStartOperator.Run(ctx)
+	report := sapSystemStopOperator.Run(ctx)
 
 	suite.Nil(report.Success)
 	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
@@ -101,7 +101,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceTypeInvali
 func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceTypeUnknown() {
 	ctx := context.Background()
 
-	sapSystemStartOperator := operator.NewSAPSystemStop(
+	sapSystemStopOperator := operator.NewSAPSystemStop(
 		operator.OperatorArguments{
 			"instance_number": "00",
 			"instance_type":   "unknown",
@@ -110,7 +110,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceTypeUnknow
 		operator.OperatorOptions[operator.SAPSystemStop]{},
 	)
 
-	report := sapSystemStartOperator.Run(ctx)
+	report := sapSystemStopOperator.Run(ctx)
 
 	suite.Nil(report.Success)
 	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
@@ -125,7 +125,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopPlanError() {
 		Return(nil, errors.New("error getting instances")).
 		Once()
 
-	sapSystemStartOperator := operator.NewSAPSystemStop(
+	sapSystemStopOperator := operator.NewSAPSystemStop(
 		operator.OperatorArguments{
 			"instance_number": "00",
 			"timeout":         300.0,
@@ -138,7 +138,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopPlanError() {
 		},
 	)
 
-	report := sapSystemStartOperator.Run(ctx)
+	report := sapSystemStopOperator.Run(ctx)
 
 	suite.Nil(report.Success)
 	suite.Equal(operator.PLAN, report.Error.ErrorPhase)
@@ -164,7 +164,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopCommitAlreadyStopp
 		}, nil).
 		Once()
 
-	sapSystemStartOperator := operator.NewSAPSystemStop(
+	sapSystemStopOperator := operator.NewSAPSystemStop(
 		operator.OperatorArguments{
 			"instance_number": "00",
 		},
@@ -176,7 +176,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopCommitAlreadyStopp
 		},
 	)
 
-	report := sapSystemStartOperator.Run(ctx)
+	report := sapSystemStopOperator.Run(ctx)
 
 	expectedDiff := map[string]any{
 		"before": `{"stopped":true}`,
@@ -234,7 +234,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopCommitAlreadyStopp
 			}, nil).
 			Once()
 
-		sapSystemStartOperator := operator.NewSAPSystemStop(
+		sapSystemStopOperator := operator.NewSAPSystemStop(
 			operator.OperatorArguments{
 				"instance_number": "00",
 				"instance_type":   tt.instanceType,
@@ -247,7 +247,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopCommitAlreadyStopp
 			},
 		)
 
-		report := sapSystemStartOperator.Run(ctx)
+		report := sapSystemStopOperator.Run(ctx)
 
 		expectedDiff := map[string]any{
 			"before": `{"stopped":true}`,
@@ -302,7 +302,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopCommitStoppingErro
 		Once().
 		NotBefore(rollbackStartSystem)
 
-	sapSystemStartOperator := operator.NewSAPSystemStop(
+	sapSystemStopOperator := operator.NewSAPSystemStop(
 		operator.OperatorArguments{
 			"instance_number": "00",
 		},
@@ -314,7 +314,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopCommitStoppingErro
 		},
 	)
 
-	report := sapSystemStartOperator.Run(ctx)
+	report := sapSystemStopOperator.Run(ctx)
 
 	suite.Nil(report.Success)
 	suite.Equal(operator.COMMIT, report.Error.ErrorPhase)
@@ -369,7 +369,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopVerifyError() {
 		Once().
 		NotBefore(rollbackStartSystem)
 
-	sapSystemStartOperator := operator.NewSAPSystemStop(
+	sapSystemStopOperator := operator.NewSAPSystemStop(
 		operator.OperatorArguments{
 			"instance_number": "00",
 		},
@@ -381,7 +381,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopVerifyError() {
 		},
 	)
 
-	report := sapSystemStartOperator.Run(ctx)
+	report := sapSystemStopOperator.Run(ctx)
 
 	suite.Nil(report.Success)
 	suite.Equal(operator.VERIFY, report.Error.ErrorPhase)
@@ -410,7 +410,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopVerifyTimeout() {
 		On("StartSystemContext", ctx, mock.Anything).
 		Return(nil, nil)
 
-	sapSystemStartOperator := operator.NewSAPSystemStop(
+	sapSystemStopOperator := operator.NewSAPSystemStop(
 		operator.OperatorArguments{
 			"instance_number": "00",
 			"timeout":         0.0,
@@ -424,7 +424,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopVerifyTimeout() {
 		},
 	)
 
-	report := sapSystemStartOperator.Run(ctx)
+	report := sapSystemStopOperator.Run(ctx)
 
 	suite.Nil(report.Success)
 	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
@@ -463,7 +463,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopRollbackStoppingEr
 		).
 		Return(nil, errors.New("error starting"))
 
-	sapSystemStartOperator := operator.NewSAPSystemStop(
+	sapSystemStopOperator := operator.NewSAPSystemStop(
 		operator.OperatorArguments{
 			"instance_number": "00",
 			"instance_type":   "abap",
@@ -476,7 +476,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopRollbackStoppingEr
 		},
 	)
 
-	report := sapSystemStartOperator.Run(ctx)
+	report := sapSystemStopOperator.Run(ctx)
 
 	suite.Nil(report.Success)
 	suite.Equal(operator.ROLLBACK, report.Error.ErrorPhase)
@@ -559,7 +559,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopSuccess() {
 			Once().
 			NotBefore(stopSystem)
 
-		sapSystemStartOperator := operator.NewSAPSystemStop(
+		sapSystemStopOperator := operator.NewSAPSystemStop(
 			operator.OperatorArguments{
 				"instance_number": "00",
 				"instance_type":   tt.instanceType,
@@ -572,7 +572,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopSuccess() {
 			},
 		)
 
-		report := sapSystemStartOperator.Run(ctx)
+		report := sapSystemStopOperator.Run(ctx)
 
 		expectedDiff := map[string]any{
 			"before": `{"stopped":false}`,
@@ -634,7 +634,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopSuccessMultipleQue
 		).
 		Once()
 
-	sapSystemStartOperator := operator.NewSAPSystemStop(
+	sapSystemStopOperator := operator.NewSAPSystemStop(
 		operator.OperatorArguments{
 			"instance_number": "00",
 			"timeout":         5.0,
@@ -648,7 +648,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopSuccessMultipleQue
 		},
 	)
 
-	report := sapSystemStartOperator.Run(ctx)
+	report := sapSystemStopOperator.Run(ctx)
 
 	expectedDiff := map[string]any{
 		"before": `{"stopped":false}`,


### PR DESCRIPTION
# Description

`SAPSystemStop` operator. Twin operator of `SAPSystemStart`: https://github.com/trento-project/workbench/pull/33

## How was this tested?

UT copied and adapter from the `SapSystemStart` operator
