### PR TITLE
Use Waittimeout in StartSystemContext commands

### DIFF
--- a/pkg/operator/sapsystemstart_v1.go
+++ b/pkg/operator/sapsystemstart_v1.go
@@ -135,6 +135,10 @@ func (s *SAPSystemStart) plan(ctx context.Context) (bool, error) {
 func (s *SAPSystemStart) commit(ctx context.Context) error {
 	request := new(sapcontrol.StartSystem)
 	request.Options = &s.parsedArguments.instanceType
+	// Even though the timeout is optional, the action doesn't work if a value is not set
+	// and `all` instance_type is used. It is sent as 0, which means that it
+	// would hit the timeout and stop the operation
+	request.Waittimeout = int32(s.parsedArguments.timeout.Seconds())
 	_, err := s.sapControlConnector.StartSystemContext(ctx, request)
 	if err != nil {
 		return fmt.Errorf("error starting system: %w", err)

--- a/pkg/operator/sapsystemstart_v1_test.go
+++ b/pkg/operator/sapsystemstart_v1_test.go
@@ -519,6 +519,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartSuccess() {
 	for _, tt := range cases {
 		ctx := context.Background()
 		suite.mockSapcontrol = mocks.NewMockSAPControlConnector(suite.T())
+		timeout := 60.0
 
 		green := sapcontrol.STATECOLORSAPControlGREEN
 		gray := sapcontrol.STATECOLORSAPControlGRAY
@@ -540,7 +541,10 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartSuccess() {
 				"StartSystemContext",
 				ctx,
 				mock.MatchedBy(func(req *sapcontrol.StartSystem) bool {
-					return *req.Options == tt.options
+					if *req.Options == tt.options && req.Waittimeout == int32(timeout) {
+						return true
+					}
+					return false
 				}),
 			).
 			Return(nil, nil).
@@ -561,6 +565,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartSuccess() {
 			operator.OperatorArguments{
 				"instance_number": "00",
 				"instance_type":   tt.instanceType,
+				"timeout":         timeout,
 			},
 			"test-op",
 			operator.OperatorOptions[operator.SAPSystemStart]{

--- a/pkg/operator/sapsystemstop_v1.go
+++ b/pkg/operator/sapsystemstop_v1.go
@@ -148,6 +148,7 @@ func (s *SAPSystemStop) verify(ctx context.Context) error {
 func (s *SAPSystemStop) rollback(ctx context.Context) error {
 	request := new(sapcontrol.StartSystem)
 	request.Options = &s.parsedArguments.instanceType
+	request.Waittimeout = int32(s.parsedArguments.timeout.Seconds())
 	_, err := s.sapControlConnector.StartSystemContext(ctx, request)
 	if err != nil {
 		return fmt.Errorf("error starting system: %w", err)

--- a/pkg/operator/sapsystemstop_v1_test.go
+++ b/pkg/operator/sapsystemstop_v1_test.go
@@ -458,7 +458,10 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopRollbackStoppingEr
 			"StartSystemContext",
 			ctx,
 			mock.MatchedBy(func(req *sapcontrol.StartSystem) bool {
-				return *req.Options == sapcontrol.StartStopOptionSAPControlABAPINSTANCES
+				if *req.Options == sapcontrol.StartStopOptionSAPControlABAPINSTANCES && req.Waittimeout == 300.0 {
+					return true
+				}
+				return false
 			}),
 		).
 		Return(nil, errors.New("error starting"))


### PR DESCRIPTION
# Description

Use the `Waittimeout` option in the `StartSystemContext` sapcontrol command.
If the value is set, it is defaulted to 0, which causes issues when the `all` instance type is used.
Putting 0 means that the timeout is expired immediately, so the command only starts the first layer of instances with the lowest priority level. We were seeing that only the `ENQREP` was being started, and this was the reason.
In fact, putting the timeout is a good idea either way, as it won't start more instances when the operator timeout is stopped, not having "background" activities when the operator fails due timeout.

Some reference (search for `waittimeout`): https://www.sap.com/documents/2016/09/0a40e60d-8b7c-0010-82c7-eda71af511fa.html

PD: The `StopSystemContext` doesn't really need this value, as the behaviour is different for that command.

## How was this tested?

UT and doing a lot of manual test in real setups
