### PR TITLE
Add linter config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,63 @@
+version: "2"
+linters:
+  enable:
+    - containedctx
+    - copyloopvar
+    - dogsled
+    - dupl
+    - durationcheck
+    - errchkjson
+    - errorlint
+    - exhaustive
+    - forbidigo
+    - forcetypeassert
+    - gochecknoglobals
+    - goconst
+    - gocritic
+    - gomoddirectives
+    - gomodguard
+    - gosec
+    - importas
+    - lll
+    - misspell
+    - nilerr
+    - nilnil
+    - nonamedreturns
+    - prealloc
+    - predeclared
+    - revive
+    - testpackage
+    - unconvert
+    - unparam
+    - wastedassign
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: _test\.go
+        linters:
+          - lll
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+  settings:
+    exhaustive:
+      default-signifies-exhaustive: true
+    staticcheck:
+      checks:
+        - "^ST1005" # error strings should not be capitalized
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,8 +50,10 @@ linters:
         linters:
           - revive
         text: "exported:*"
-        path: internal/sapcontrol/webservice\.go
-        disable: true
+      # ignore dupl in tests, as we prefer copy-paste over abstraction there
+      - path: ".*_test\\.go"
+        linters:
+          - dupl
     paths:
       - third_party$
       - builtin$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -41,12 +41,15 @@ linters:
       - path: _test\.go
         linters:
           - lll
-        path: _test\.go
-        rules:
-      # sapcontrol generated code, ignore var naming issues
-      - linters:
+      # sapcontrol generated code, ignore naming issues
+      - path: internal/sapcontrol/webservice\.go
+        linters:
           - revive
         text: "var-naming:*"
+      - path: internal/sapcontrol/webservice\.go
+        linters:
+          - revive
+        text: "exported:*"
         path: internal/sapcontrol/webservice\.go
         disable: true
     paths:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -42,6 +42,13 @@ linters:
         linters:
           - lll
         path: _test\.go
+        rules:
+      # sapcontrol generated code, ignore var naming issues
+      - linters:
+          - revive
+        text: "var-naming:*"
+        path: internal/sapcontrol/webservice\.go
+        disable: true
     paths:
       - third_party$
       - builtin$

--- a/cmd/workbench.go
+++ b/cmd/workbench.go
@@ -49,7 +49,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	opArgs := make(operator.OperatorArguments)
+	opArgs := make(operator.Arguments)
 	err = json.Unmarshal([]byte(options.Arguments), &opArgs)
 	if err != nil {
 		logger.Error("could not unmarshal options arguments", "arguments", options.Arguments)

--- a/cmd/workbench.go
+++ b/cmd/workbench.go
@@ -11,17 +11,16 @@ import (
 	"github.com/trento-project/workbench/pkg/operator"
 )
 
-var Version string
-
 type cliOptions struct {
 	Arguments string `long:"arguments" short:"a" description:"Json arguments of an operator" required:"true"`
 	Verbose   bool   `long:"verbose" short:"v" description:"Log verbosity"`
 }
 
-var options cliOptions
-var flagParser = flags.NewParser(&options, flags.Default) //nolint
-
 func main() {
+	var version string
+	var options cliOptions
+	var flagParser = flags.NewParser(&options, flags.Default)
+
 	ctx := context.Background()
 
 	args, err := flagParser.Parse()
@@ -38,7 +37,7 @@ func main() {
 
 	logger := support.NewDefaultLogger(logLevel)
 
-	logger.Info("starting workbench CLI", "version", Version)
+	logger.Info("starting workbench CLI", "version", version)
 
 	operatorName := args[0]
 	registry := operator.StandardRegistry(operator.WithCustomLogger(logger))

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -18,7 +18,7 @@ type Cluster interface {
 	StopCluster(ctx context.Context) error
 }
 
-type ClusterClient struct {
+type Client struct {
 	executor support.CmdExecutor
 	logger   *slog.Logger
 }
@@ -31,13 +31,13 @@ func NewDefaultClusterClient() Cluster {
 }
 
 func NewClusterClient(executor support.CmdExecutor, logger *slog.Logger) Cluster {
-	return &ClusterClient{
+	return &Client{
 		executor: executor,
 		logger:   logger,
 	}
 }
 
-func (c *ClusterClient) IsHostOnline(ctx context.Context) bool {
+func (c *Client) IsHostOnline(ctx context.Context) bool {
 	output, err := c.executor.Exec(ctx, "crm", "status", "simple")
 	if err != nil {
 		return false
@@ -48,7 +48,7 @@ func (c *ClusterClient) IsHostOnline(ctx context.Context) bool {
 	return true
 }
 
-func (c *ClusterClient) StartCluster(ctx context.Context) error {
+func (c *Client) StartCluster(ctx context.Context) error {
 	c.logger.Info("Starting CRM cluster")
 	output, err := c.executor.Exec(ctx, "crm", "cluster", "start")
 	if err != nil {
@@ -59,7 +59,7 @@ func (c *ClusterClient) StartCluster(ctx context.Context) error {
 	return nil
 }
 
-func (c *ClusterClient) StopCluster(ctx context.Context) error {
+func (c *Client) StopCluster(ctx context.Context) error {
 	c.logger.Info("Stopping CRM cluster")
 	output, err := c.executor.Exec(ctx, "crm", "cluster", "stop")
 	if err != nil {
@@ -70,7 +70,7 @@ func (c *ClusterClient) StopCluster(ctx context.Context) error {
 	return nil
 }
 
-func (c *ClusterClient) IsIdle(ctx context.Context) (bool, error) {
+func (c *Client) IsIdle(ctx context.Context) (bool, error) {
 	idleOutput, err := c.executor.Exec(ctx, "cs_clusterstate", "-i")
 	if err != nil {
 		return false, fmt.Errorf("error running cs_clusterstate: %w", err)

--- a/internal/dbus/dbus.go
+++ b/internal/dbus/dbus.go
@@ -6,11 +6,19 @@ import (
 	"github.com/coreos/go-systemd/v22/dbus"
 )
 
-// Connector acts as an abstract interface for the dbus functionalities exposed by the package "github.com/coreos/go-systemd/v22/dbus"
+// Connector acts as an abstract interface for the dbus functionalities exposed
+// by the package "github.com/coreos/go-systemd/v22/dbus"
 type Connector interface {
 	GetUnitPropertyContext(ctx context.Context, unit string, propertyName string) (*dbus.Property, error)
-	EnableUnitFilesContext(ctx context.Context, files []string, runtime bool, force bool) (bool, []dbus.EnableUnitFileChange, error)
-	DisableUnitFilesContext(ctx context.Context, files []string, runtime bool) ([]dbus.DisableUnitFileChange, error)
+	EnableUnitFilesContext(ctx context.Context, files []string, runtime bool, force bool) (
+		bool,
+		[]dbus.EnableUnitFileChange,
+		error,
+	)
+	DisableUnitFilesContext(ctx context.Context, files []string, runtime bool) (
+		[]dbus.DisableUnitFileChange,
+		error,
+	)
 	ReloadContext(ctx context.Context) error
 	ListJobsContext(ctx context.Context) ([]dbus.JobStatus, error)
 	ListUnitsContext(ctx context.Context) ([]dbus.UnitStatus, error)

--- a/internal/dbus/dbus.go
+++ b/internal/dbus/dbus.go
@@ -6,8 +6,8 @@ import (
 	"github.com/coreos/go-systemd/v22/dbus"
 )
 
-// DbusConnector acts as an abstract interface for the dbus functionalities exposed by the package "github.com/coreos/go-systemd/v22/dbus"
-type DbusConnector interface {
+// Connector acts as an abstract interface for the dbus functionalities exposed by the package "github.com/coreos/go-systemd/v22/dbus"
+type Connector interface {
 	GetUnitPropertyContext(ctx context.Context, unit string, propertyName string) (*dbus.Property, error)
 	EnableUnitFilesContext(ctx context.Context, files []string, runtime bool, force bool) (bool, []dbus.EnableUnitFileChange, error)
 	DisableUnitFilesContext(ctx context.Context, files []string, runtime bool) ([]dbus.DisableUnitFileChange, error)
@@ -20,7 +20,7 @@ type DbusConnector interface {
 	Close()
 }
 
-func NewDbusConnector(ctx context.Context) (DbusConnector, error) {
+func NewConnector(ctx context.Context) (Connector, error) {
 	// the created connection does implement the DbusConnector interface, hence it can be returned as such
 	dbusConnection, err := dbus.NewWithContext(ctx)
 	if err != nil {

--- a/internal/sapcontrol/webservice.go
+++ b/internal/sapcontrol/webservice.go
@@ -126,7 +126,10 @@ type SAPControlConnector interface {
 	/* Returns a list of all processes directly started by the webservice according to the SAP start profile. */
 	GetProcessListContext(ctx context.Context, request *GetProcessList) (*GetProcessListResponse, error)
 	/* Returns a list of SAP instances of the SAP system. */
-	GetSystemInstanceListContext(ctx context.Context, request *GetSystemInstanceList) (*GetSystemInstanceListResponse, error)
+	GetSystemInstanceListContext(
+		ctx context.Context,
+		request *GetSystemInstanceList,
+	) (*GetSystemInstanceListResponse, error)
 }
 
 type sapControlConnector struct {
@@ -175,7 +178,10 @@ func (service *sapControlConnector) StopContext(ctx context.Context, request *St
 	return response, nil
 }
 
-func (service *sapControlConnector) StartSystemContext(ctx context.Context, request *StartSystem) (*StartSystemResponse, error) {
+func (service *sapControlConnector) StartSystemContext(
+	ctx context.Context,
+	request *StartSystem,
+) (*StartSystemResponse, error) {
 	response := new(StartSystemResponse)
 	err := service.client.CallContext(ctx, "''", request, response)
 	if err != nil {
@@ -185,7 +191,10 @@ func (service *sapControlConnector) StartSystemContext(ctx context.Context, requ
 	return response, nil
 }
 
-func (service *sapControlConnector) StopSystemContext(ctx context.Context, request *StopSystem) (*StopSystemResponse, error) {
+func (service *sapControlConnector) StopSystemContext(
+	ctx context.Context,
+	request *StopSystem,
+) (*StopSystemResponse, error) {
 	response := new(StopSystemResponse)
 	err := service.client.CallContext(ctx, "''", request, response)
 	if err != nil {
@@ -195,7 +204,10 @@ func (service *sapControlConnector) StopSystemContext(ctx context.Context, reque
 	return response, nil
 }
 
-func (service *sapControlConnector) GetProcessListContext(ctx context.Context, request *GetProcessList) (*GetProcessListResponse, error) {
+func (service *sapControlConnector) GetProcessListContext(
+	ctx context.Context,
+	request *GetProcessList,
+) (*GetProcessListResponse, error) {
 	response := new(GetProcessListResponse)
 	err := service.client.CallContext(ctx, "''", request, response)
 	if err != nil {
@@ -205,7 +217,10 @@ func (service *sapControlConnector) GetProcessListContext(ctx context.Context, r
 	return response, nil
 }
 
-func (service *sapControlConnector) GetSystemInstanceListContext(ctx context.Context, request *GetSystemInstanceList) (*GetSystemInstanceListResponse, error) {
+func (service *sapControlConnector) GetSystemInstanceListContext(
+	ctx context.Context,
+	request *GetSystemInstanceList,
+) (*GetSystemInstanceListResponse, error) {
 	response := new(GetSystemInstanceListResponse)
 	err := service.client.CallContext(ctx, "''", request, response)
 	if err != nil {

--- a/internal/saptune/saptune.go
+++ b/internal/saptune/saptune.go
@@ -76,7 +76,7 @@ func (saptune *saptuneClient) ApplySolution(ctx context.Context, solution string
 			"solution", solution,
 			"error_output", applyOutput)
 
-		return fmt.Errorf("could not perform saptune solution apply %s, error: %s",
+		return fmt.Errorf("could not perform saptune solution apply %s, error: %w",
 			solution,
 			err,
 		)
@@ -92,7 +92,7 @@ func (saptune *saptuneClient) ChangeSolution(ctx context.Context, solution strin
 			"solution", solution,
 			"error_output", changeSolutionOutput)
 
-		return fmt.Errorf("could not perform saptune change solution %s, error: %s",
+		return fmt.Errorf("could not perform saptune change solution %s, error: %w",
 			solution,
 			err,
 		)
@@ -106,7 +106,7 @@ func (saptune *saptuneClient) RevertSolution(ctx context.Context, solution strin
 	if err != nil {
 		saptune.logger.Error("could not perform saptune solution revert", "solution", solution, "error_output", revertOutput)
 
-		return fmt.Errorf("could not perform saptune solution revert %s, error: %s",
+		return fmt.Errorf("could not perform saptune solution revert %s, error: %w",
 			solution,
 			err,
 		)

--- a/internal/systemd/mocks/mock_SystemdLoader.go
+++ b/internal/systemd/mocks/mock_SystemdLoader.go
@@ -25,7 +25,7 @@ func (_m *MockSystemdLoader) EXPECT() *MockSystemdLoader_Expecter {
 }
 
 // NewSystemd provides a mock function with given fields: ctx, logger, options
-func (_m *MockSystemdLoader) NewSystemd(ctx context.Context, logger *slog.Logger, options ...systemd.SystemdConnectorOption) (systemd.Systemd, error) {
+func (_m *MockSystemdLoader) NewSystemd(ctx context.Context, logger *slog.Logger, options ...systemd.ConnectorOption) (systemd.Systemd, error) {
 	_va := make([]interface{}, len(options))
 	for _i := range options {
 		_va[_i] = options[_i]
@@ -41,10 +41,10 @@ func (_m *MockSystemdLoader) NewSystemd(ctx context.Context, logger *slog.Logger
 
 	var r0 systemd.Systemd
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *slog.Logger, ...systemd.SystemdConnectorOption) (systemd.Systemd, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *slog.Logger, ...systemd.ConnectorOption) (systemd.Systemd, error)); ok {
 		return rf(ctx, logger, options...)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *slog.Logger, ...systemd.SystemdConnectorOption) systemd.Systemd); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *slog.Logger, ...systemd.ConnectorOption) systemd.Systemd); ok {
 		r0 = rf(ctx, logger, options...)
 	} else {
 		if ret.Get(0) != nil {
@@ -52,7 +52,7 @@ func (_m *MockSystemdLoader) NewSystemd(ctx context.Context, logger *slog.Logger
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *slog.Logger, ...systemd.SystemdConnectorOption) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *slog.Logger, ...systemd.ConnectorOption) error); ok {
 		r1 = rf(ctx, logger, options...)
 	} else {
 		r1 = ret.Error(1)
@@ -75,12 +75,12 @@ func (_e *MockSystemdLoader_Expecter) NewSystemd(ctx interface{}, logger interfa
 		append([]interface{}{ctx, logger}, options...)...)}
 }
 
-func (_c *MockSystemdLoader_NewSystemd_Call) Run(run func(ctx context.Context, logger *slog.Logger, options ...systemd.SystemdConnectorOption)) *MockSystemdLoader_NewSystemd_Call {
+func (_c *MockSystemdLoader_NewSystemd_Call) Run(run func(ctx context.Context, logger *slog.Logger, options ...systemd.ConnectorOption)) *MockSystemdLoader_NewSystemd_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]systemd.SystemdConnectorOption, len(args)-2)
+		variadicArgs := make([]systemd.ConnectorOption, len(args)-2)
 		for i, a := range args[2:] {
 			if a != nil {
-				variadicArgs[i] = a.(systemd.SystemdConnectorOption)
+				variadicArgs[i] = a.(systemd.ConnectorOption)
 			}
 		}
 		run(args[0].(context.Context), args[1].(*slog.Logger), variadicArgs...)
@@ -93,7 +93,7 @@ func (_c *MockSystemdLoader_NewSystemd_Call) Return(_a0 systemd.Systemd, _a1 err
 	return _c
 }
 
-func (_c *MockSystemdLoader_NewSystemd_Call) RunAndReturn(run func(context.Context, *slog.Logger, ...systemd.SystemdConnectorOption) (systemd.Systemd, error)) *MockSystemdLoader_NewSystemd_Call {
+func (_c *MockSystemdLoader_NewSystemd_Call) RunAndReturn(run func(context.Context, *slog.Logger, ...systemd.ConnectorOption) (systemd.Systemd, error)) *MockSystemdLoader_NewSystemd_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -28,7 +28,11 @@ type Loader interface {
 
 type defaultSystemdLoader struct{}
 
-func (d *defaultSystemdLoader) NewSystemd(ctx context.Context, logger *slog.Logger, options ...ConnectorOption) (Systemd, error) {
+func (d *defaultSystemdLoader) NewSystemd(
+	ctx context.Context,
+	logger *slog.Logger,
+	options ...ConnectorOption,
+) (Systemd, error) {
 	return NewSystemd(ctx, logger, options...)
 }
 

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -16,7 +16,7 @@ type Systemd interface {
 }
 
 type SystemdConnector struct {
-	dbusConnection dbus.DbusConnector
+	dbusConnection dbus.Connector
 	logger         *slog.Logger
 }
 
@@ -36,7 +36,7 @@ func NewDefaultSystemdLoader() SystemdLoader {
 	return &defaultSystemdLoader{}
 }
 
-func WithCustomDbusConnector(dbusConnection dbus.DbusConnector) SystemdConnectorOption {
+func WithCustomDbusConnector(dbusConnection dbus.Connector) SystemdConnectorOption {
 	return func(s *SystemdConnector) {
 		s.dbusConnection = dbusConnection
 	}
@@ -55,7 +55,7 @@ func NewSystemd(ctx context.Context, logger *slog.Logger, options ...SystemdConn
 		return systemdInstance, nil
 	}
 
-	dbusConnection, err := dbus.NewDbusConnector(ctx)
+	dbusConnection, err := dbus.NewConnector(ctx)
 	if err != nil {
 		logger.Error("failed to create dbus connection", "error", err)
 		return nil, err

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -96,7 +96,15 @@ func (s *Connector) IsEnabled(ctx context.Context, service string) (bool, error)
 		return false, fmt.Errorf("failed to get unit file state for service %s: %w", service, err)
 	}
 
-	return unitFileState.Value.Value().(string) == "enabled", nil
+	value, ok := unitFileState.Value.Value().(string)
+	if !ok {
+		s.logger.Error("unexpected type for unit file state", "service", service,
+			"type", fmt.Sprintf("%T", unitFileState.Value.Value()))
+		return false, fmt.Errorf("unexpected type for unit file state of service %s: %T",
+			service, unitFileState.Value.Value())
+	}
+
+	return value == "enabled", nil
 }
 
 func (s *Connector) Close() {

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -22,7 +22,7 @@ type Connector struct {
 
 type ConnectorOption func(*Connector)
 
-type SystemdLoader interface {
+type Loader interface {
 	NewSystemd(ctx context.Context, logger *slog.Logger, options ...ConnectorOption) (Systemd, error)
 }
 
@@ -32,7 +32,7 @@ func (d *defaultSystemdLoader) NewSystemd(ctx context.Context, logger *slog.Logg
 	return NewSystemd(ctx, logger, options...)
 }
 
-func NewDefaultSystemdLoader() SystemdLoader {
+func NewDefaultSystemdLoader() Loader {
 	return &defaultSystemdLoader{}
 }
 

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -20,15 +20,15 @@ type Connector struct {
 	logger         *slog.Logger
 }
 
-type SystemdConnectorOption func(*Connector)
+type ConnectorOption func(*Connector)
 
 type SystemdLoader interface {
-	NewSystemd(ctx context.Context, logger *slog.Logger, options ...SystemdConnectorOption) (Systemd, error)
+	NewSystemd(ctx context.Context, logger *slog.Logger, options ...ConnectorOption) (Systemd, error)
 }
 
 type defaultSystemdLoader struct{}
 
-func (d *defaultSystemdLoader) NewSystemd(ctx context.Context, logger *slog.Logger, options ...SystemdConnectorOption) (Systemd, error) {
+func (d *defaultSystemdLoader) NewSystemd(ctx context.Context, logger *slog.Logger, options ...ConnectorOption) (Systemd, error) {
 	return NewSystemd(ctx, logger, options...)
 }
 
@@ -36,13 +36,13 @@ func NewDefaultSystemdLoader() SystemdLoader {
 	return &defaultSystemdLoader{}
 }
 
-func WithCustomDbusConnector(dbusConnection dbus.Connector) SystemdConnectorOption {
+func WithCustomDbusConnector(dbusConnection dbus.Connector) ConnectorOption {
 	return func(s *Connector) {
 		s.dbusConnection = dbusConnection
 	}
 }
 
-func NewSystemd(ctx context.Context, logger *slog.Logger, options ...SystemdConnectorOption) (Systemd, error) {
+func NewSystemd(ctx context.Context, logger *slog.Logger, options ...ConnectorOption) (Systemd, error) {
 	systemdInstance := &Connector{
 		logger: logger,
 	}

--- a/pkg/operator/base.go
+++ b/pkg/operator/base.go
@@ -21,7 +21,7 @@ func WithCustomLogger(logger *slog.Logger) BaseOperatorOption {
 }
 
 type baseOperator struct {
-	arguments OperatorArguments
+	arguments Arguments
 	resources map[string]any
 	logger    *slog.Logger
 }
@@ -29,7 +29,7 @@ type baseOperator struct {
 func newBaseOperator(
 	name string,
 	operationID string,
-	arguments OperatorArguments,
+	arguments Arguments,
 	options ...BaseOperatorOption,
 ) baseOperator {
 	base := &baseOperator{

--- a/pkg/operator/clustermaintenancechange_v1.go
+++ b/pkg/operator/clustermaintenancechange_v1.go
@@ -131,11 +131,12 @@ func (c *ClusterMaintenanceChange) plan(ctx context.Context) (bool, error) {
 	}
 	c.parsedArguments = opArguments
 
-	if c.parsedArguments.resourceID != "" {
+	switch {
+	case c.parsedArguments.resourceID != "":
 		c.scope = resourceScope
-	} else if c.parsedArguments.nodeID != "" {
+	case c.parsedArguments.nodeID != "":
 		c.scope = nodeScope
-	} else {
+	default:
 		c.scope = clusterScope
 	}
 

--- a/pkg/operator/clustermaintenancechange_v1.go
+++ b/pkg/operator/clustermaintenancechange_v1.go
@@ -101,7 +101,7 @@ func WithCustomClusterMaintenanceExecutor(executor support.CmdExecutor) ClusterM
 }
 
 func NewClusterMaintenanceChange(
-	arguments OperatorArguments,
+	arguments Arguments,
 	operationID string,
 	options OperatorOptions[ClusterMaintenanceChange],
 ) *Executor {
@@ -391,7 +391,7 @@ func parseStateOutput(output []byte) (bool, error) {
 	return boolValue, nil
 }
 
-func parseClusterMaintenanceArguments(rawArguments OperatorArguments) (*clusterMaintenanceChangeArguments, error) {
+func parseClusterMaintenanceArguments(rawArguments Arguments) (*clusterMaintenanceChangeArguments, error) {
 	var resourceID, nodeID string
 
 	maintenanceArgument, found := rawArguments["maintenance"]

--- a/pkg/operator/clustermaintenancechange_v1.go
+++ b/pkg/operator/clustermaintenancechange_v1.go
@@ -213,7 +213,7 @@ func (c *ClusterMaintenanceChange) rollback(ctx context.Context) error {
 	return nil
 }
 
-func (c *ClusterMaintenanceChange) operationDiff(ctx context.Context) map[string]any {
+func (c *ClusterMaintenanceChange) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
 	beforeDiffOutput := diffOutput{

--- a/pkg/operator/clustermaintenancechange_v1.go
+++ b/pkg/operator/clustermaintenancechange_v1.go
@@ -217,8 +217,20 @@ func (c *ClusterMaintenanceChange) rollback(ctx context.Context) error {
 func (c *ClusterMaintenanceChange) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
+	beforeMaintenance, ok := c.resources[beforeDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid beforeMaintenance value: cannot parse '%s' to bool",
+			c.resources[beforeDiffField]))
+	}
+
+	afterMaintenance, ok := c.resources[afterDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid afterMaintenance value: cannot parse '%s' to bool",
+			c.resources[afterDiffField]))
+	}
+
 	beforeDiffOutput := diffOutput{
-		Maintenance: c.resources[beforeDiffField].(bool),
+		Maintenance: beforeMaintenance,
 		ResourceID:  c.parsedArguments.resourceID,
 		NodeID:      c.parsedArguments.nodeID,
 	}
@@ -226,7 +238,7 @@ func (c *ClusterMaintenanceChange) operationDiff(_ context.Context) map[string]a
 	diff["before"] = string(before)
 
 	afterDiffOutput := diffOutput{
-		Maintenance: c.resources[afterDiffField].(bool),
+		Maintenance: afterMaintenance,
 		ResourceID:  c.parsedArguments.resourceID,
 		NodeID:      c.parsedArguments.nodeID,
 	}

--- a/pkg/operator/clustermaintenancechange_v1.go
+++ b/pkg/operator/clustermaintenancechange_v1.go
@@ -103,7 +103,7 @@ func WithCustomClusterMaintenanceExecutor(executor support.CmdExecutor) ClusterM
 func NewClusterMaintenanceChange(
 	arguments Arguments,
 	operationID string,
-	options OperatorOptions[ClusterMaintenanceChange],
+	options Options[ClusterMaintenanceChange],
 ) *Executor {
 	clusterMaintenance := &ClusterMaintenanceChange{
 		baseOperator: newBaseOperator(

--- a/pkg/operator/clustermaintenancechange_v1.go
+++ b/pkg/operator/clustermaintenancechange_v1.go
@@ -235,7 +235,10 @@ func (c *ClusterMaintenanceChange) operationDiff(_ context.Context) map[string]a
 		ResourceID:  c.parsedArguments.resourceID,
 		NodeID:      c.parsedArguments.nodeID,
 	}
-	before, _ := json.Marshal(beforeDiffOutput)
+	before, err := json.Marshal(beforeDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling before diff output: %v", err))
+	}
 	diff["before"] = string(before)
 
 	afterDiffOutput := diffOutput{
@@ -243,7 +246,10 @@ func (c *ClusterMaintenanceChange) operationDiff(_ context.Context) map[string]a
 		ResourceID:  c.parsedArguments.resourceID,
 		NodeID:      c.parsedArguments.nodeID,
 	}
-	after, _ := json.Marshal(afterDiffOutput)
+	after, err := json.Marshal(afterDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling after diff output: %v", err))
+	}
 	diff["after"] = string(after)
 
 	return diff

--- a/pkg/operator/clustermaintenancechange_v1.go
+++ b/pkg/operator/clustermaintenancechange_v1.go
@@ -54,6 +54,7 @@ type diffOutput struct {
 //
 // Find some helpful references about maintenance transitions and used commands:
 // - https://www.suse.com/c/sles-for-sap-hana-maintenance-procedures-part-1-pre-maintenance-checks/
+// nolint:lll
 // - https://www.suse.com/c/sles-for-sap-hana-maintenance-procedures-part-2-manual-administrative-tasks-os-reboots-and-updation-of-os-and-hana/
 // - https://crmsh.github.io/man-4.6/
 // - https://crmsh.github.io/man-4.6/#cmdhelp_root_status

--- a/pkg/operator/clustermaintenancechange_v1_test.go
+++ b/pkg/operator/clustermaintenancechange_v1_test.go
@@ -61,7 +61,7 @@ func TestClusterMaintenanceChangeSuccessOn(t *testing.T) {
 			"maintenance": true,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -140,7 +140,7 @@ func TestClusterMaintenanceChangeSuccessOff(t *testing.T) {
 			"maintenance": false,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -215,7 +215,7 @@ func TestClusterMaintenanceChangeResourceSuccess(t *testing.T) {
 			"resource_id": resourceID,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -303,7 +303,7 @@ func TestClusterMaintenanceChangeResourceWithIsManagedSuccess(t *testing.T) {
 			"resource_id": resourceID,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -389,7 +389,7 @@ func TestClusterMaintenanceChangeResourceDefaultSuccess(t *testing.T) {
 			"resource_id": resourceID,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -465,7 +465,7 @@ func TestClusterMaintenanceChangeNodeSuccessOn(t *testing.T) {
 			"node_id":     nodeID,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -544,7 +544,7 @@ func TestClusterMaintenanceChangeNodeSuccessOnWithoutPreviousState(t *testing.T)
 			"node_id":     nodeID,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -629,7 +629,7 @@ func TestClusterMaintenanceChangeNodeSuccessOff(t *testing.T) {
 			"node_id":     nodeID,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -655,7 +655,7 @@ func TestClusterMaintenanceChangeMissingArgument(t *testing.T) {
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
 		operator.Arguments{},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -678,7 +678,7 @@ func TestClusterMaintenanceChangeInvalidArgument(t *testing.T) {
 			"maintenance": "on",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -702,7 +702,7 @@ func TestClusterMaintenanceChangeInvalidResourceIDArgument(t *testing.T) {
 			"resource_id": 1,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -726,7 +726,7 @@ func TestClusterMaintenanceChangeInvalidNodeIDArgument(t *testing.T) {
 			"node_id":     1,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -751,7 +751,7 @@ func TestClusterMaintenanceChangeMutuallyExclusiveArgument(t *testing.T) {
 			"node_id":     "some-node",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -781,7 +781,7 @@ func TestClusterMaintenanceChangePlanClusterNotFound(t *testing.T) {
 			"maintenance": true,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -821,7 +821,7 @@ func TestClusterMaintenanceChangePlanGetMaintenanceError(t *testing.T) {
 			"maintenance": true,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -861,7 +861,7 @@ func TestClusterMaintenanceChangePlanEmptyMaintenanceState(t *testing.T) {
 			"maintenance": true,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -904,7 +904,7 @@ func TestClusterMaintenanceChangePlanNodeNotFound(t *testing.T) {
 			"node_id":     nodeID,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -944,7 +944,7 @@ func TestClusterMaintenanceChangeCommitAlreadyApplied(t *testing.T) {
 			"maintenance": true,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -1011,7 +1011,7 @@ func TestClusterMaintenanceChangeCommitNotIdle(t *testing.T) {
 			"maintenance": true,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -1084,7 +1084,7 @@ func TestClusterMaintenanceChangeVerifyError(t *testing.T) {
 			"maintenance": true,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -1146,7 +1146,7 @@ func TestClusterMaintenanceChangeRollbackNotIdle(t *testing.T) {
 			"maintenance": true,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},
@@ -1209,7 +1209,7 @@ func TestClusterMaintenanceChangeRollbackErrorReverting(t *testing.T) {
 			"maintenance": true,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
+		operator.Options[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
 				operator.Option[operator.ClusterMaintenanceChange](operator.WithCustomClusterMaintenanceExecutor(mockCmdExecutor)),
 			},

--- a/pkg/operator/clustermaintenancechange_v1_test.go
+++ b/pkg/operator/clustermaintenancechange_v1_test.go
@@ -57,7 +57,7 @@ func TestClusterMaintenanceChangeSuccessOn(t *testing.T) {
 	).Return([]byte("true"), nil)
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 		},
 		"test-op",
@@ -136,7 +136,7 @@ func TestClusterMaintenanceChangeSuccessOff(t *testing.T) {
 	).Return([]byte("false"), nil)
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": false,
 		},
 		"test-op",
@@ -210,7 +210,7 @@ func TestClusterMaintenanceChangeResourceSuccess(t *testing.T) {
 	).Return([]byte("true"), nil)
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 			"resource_id": resourceID,
 		},
@@ -298,7 +298,7 @@ func TestClusterMaintenanceChangeResourceWithIsManagedSuccess(t *testing.T) {
 	).Return([]byte("false"), nil)
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 			"resource_id": resourceID,
 		},
@@ -384,7 +384,7 @@ func TestClusterMaintenanceChangeResourceDefaultSuccess(t *testing.T) {
 	).Return([]byte("true"), nil)
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 			"resource_id": resourceID,
 		},
@@ -460,7 +460,7 @@ func TestClusterMaintenanceChangeNodeSuccessOn(t *testing.T) {
 	).Return([]byte("scope=nodes  name=maintenance value=true"), nil)
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 			"node_id":     nodeID,
 		},
@@ -539,7 +539,7 @@ func TestClusterMaintenanceChangeNodeSuccessOnWithoutPreviousState(t *testing.T)
 	).Return([]byte("scope=nodes  name=maintenance value=true"), nil)
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 			"node_id":     nodeID,
 		},
@@ -624,7 +624,7 @@ func TestClusterMaintenanceChangeNodeSuccessOff(t *testing.T) {
 	).Return([]byte("scope=nodes  name=maintenance value=off"), nil)
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": false,
 			"node_id":     nodeID,
 		},
@@ -653,7 +653,7 @@ func TestClusterMaintenanceChangeMissingArgument(t *testing.T) {
 	ctx := context.Background()
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{},
+		operator.Arguments{},
 		"test-op",
 		operator.OperatorOptions[operator.ClusterMaintenanceChange]{
 			OperatorOptions: []operator.Option[operator.ClusterMaintenanceChange]{
@@ -674,7 +674,7 @@ func TestClusterMaintenanceChangeInvalidArgument(t *testing.T) {
 	ctx := context.Background()
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": "on",
 		},
 		"test-op",
@@ -697,7 +697,7 @@ func TestClusterMaintenanceChangeInvalidResourceIDArgument(t *testing.T) {
 	ctx := context.Background()
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 			"resource_id": 1,
 		},
@@ -721,7 +721,7 @@ func TestClusterMaintenanceChangeInvalidNodeIDArgument(t *testing.T) {
 	ctx := context.Background()
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 			"node_id":     1,
 		},
@@ -745,7 +745,7 @@ func TestClusterMaintenanceChangeMutuallyExclusiveArgument(t *testing.T) {
 	ctx := context.Background()
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 			"resource_id": "some-resource",
 			"node_id":     "some-node",
@@ -777,7 +777,7 @@ func TestClusterMaintenanceChangePlanClusterNotFound(t *testing.T) {
 	).Return([]byte("error"), errors.New("cluster not found"))
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 		},
 		"test-op",
@@ -817,7 +817,7 @@ func TestClusterMaintenanceChangePlanGetMaintenanceError(t *testing.T) {
 	).Return([]byte("error"), errors.New("cannot get state"))
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 		},
 		"test-op",
@@ -857,7 +857,7 @@ func TestClusterMaintenanceChangePlanEmptyMaintenanceState(t *testing.T) {
 	).Return([]byte(""), nil)
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 		},
 		"test-op",
@@ -899,7 +899,7 @@ func TestClusterMaintenanceChangePlanNodeNotFound(t *testing.T) {
 	).Return([]byte("Could not map name=some-id to a UUID"), errors.New("error getting node"))
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 			"node_id":     nodeID,
 		},
@@ -940,7 +940,7 @@ func TestClusterMaintenanceChangeCommitAlreadyApplied(t *testing.T) {
 	).Return([]byte("true"), nil)
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 		},
 		"test-op",
@@ -1007,7 +1007,7 @@ func TestClusterMaintenanceChangeCommitNotIdle(t *testing.T) {
 	).Return([]byte("ok"), nil)
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 		},
 		"test-op",
@@ -1080,7 +1080,7 @@ func TestClusterMaintenanceChangeVerifyError(t *testing.T) {
 	).Return([]byte("ok"), nil)
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 		},
 		"test-op",
@@ -1142,7 +1142,7 @@ func TestClusterMaintenanceChangeRollbackNotIdle(t *testing.T) {
 	).Return([]byte("S_TRANSITION"), nil)
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 		},
 		"test-op",
@@ -1205,7 +1205,7 @@ func TestClusterMaintenanceChangeRollbackErrorReverting(t *testing.T) {
 	).Return([]byte("error"), errors.New("error reverting"))
 
 	clusterMaintenanceChangeOperator := operator.NewClusterMaintenanceChange(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"maintenance": true,
 		},
 		"test-op",

--- a/pkg/operator/clustermaintenancechange_v1_test.go
+++ b/pkg/operator/clustermaintenancechange_v1_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/trento-project/workbench/pkg/operator"
 )
 
+const fakeID = "some-id"
+
 func TestClusterMaintenanceChangeSuccessOn(t *testing.T) {
 	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
 	ctx := context.Background()
@@ -162,7 +164,7 @@ func TestClusterMaintenanceChangeSuccessOff(t *testing.T) {
 func TestClusterMaintenanceChangeResourceSuccess(t *testing.T) {
 	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
 	ctx := context.Background()
-	resourceID := "some-id"
+	resourceID := fakeID
 
 	mockCmdExecutor.On(
 		"Exec",
@@ -237,7 +239,7 @@ func TestClusterMaintenanceChangeResourceSuccess(t *testing.T) {
 func TestClusterMaintenanceChangeResourceWithIsManagedSuccess(t *testing.T) {
 	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
 	ctx := context.Background()
-	resourceID := "some-id"
+	resourceID := fakeID
 
 	mockCmdExecutor.On(
 		"Exec",
@@ -325,7 +327,7 @@ func TestClusterMaintenanceChangeResourceWithIsManagedSuccess(t *testing.T) {
 func TestClusterMaintenanceChangeResourceDefaultSuccess(t *testing.T) {
 	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
 	ctx := context.Background()
-	resourceID := "some-id"
+	resourceID := fakeID
 
 	mockCmdExecutor.On(
 		"Exec",
@@ -411,7 +413,7 @@ func TestClusterMaintenanceChangeResourceDefaultSuccess(t *testing.T) {
 func TestClusterMaintenanceChangeNodeSuccessOn(t *testing.T) {
 	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
 	ctx := context.Background()
-	nodeID := "some-id"
+	nodeID := fakeID
 
 	mockCmdExecutor.On(
 		"Exec",
@@ -487,7 +489,7 @@ func TestClusterMaintenanceChangeNodeSuccessOn(t *testing.T) {
 func TestClusterMaintenanceChangeNodeSuccessOnWithoutPreviousState(t *testing.T) {
 	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
 	ctx := context.Background()
-	nodeID := "some-id"
+	nodeID := fakeID
 
 	mockCmdExecutor.On(
 		"Exec",
@@ -566,7 +568,7 @@ func TestClusterMaintenanceChangeNodeSuccessOnWithoutPreviousState(t *testing.T)
 func TestClusterMaintenanceChangeNodeSuccessOff(t *testing.T) {
 	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
 	ctx := context.Background()
-	nodeID := "some-id"
+	nodeID := fakeID
 
 	mockCmdExecutor.On(
 		"Exec",
@@ -878,7 +880,7 @@ func TestClusterMaintenanceChangePlanEmptyMaintenanceState(t *testing.T) {
 func TestClusterMaintenanceChangePlanNodeNotFound(t *testing.T) {
 	mockCmdExecutor := mocks.NewMockCmdExecutor(t)
 	ctx := context.Background()
-	nodeID := "some-id"
+	nodeID := fakeID
 
 	mockCmdExecutor.On(
 		"Exec",

--- a/pkg/operator/crmclusterstart_v1.go
+++ b/pkg/operator/crmclusterstart_v1.go
@@ -161,7 +161,7 @@ func (c *CrmClusterStart) verify(ctx context.Context) error {
 	return nil
 }
 
-func (c *CrmClusterStart) operationDiff(ctx context.Context) map[string]any {
+func (c *CrmClusterStart) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
 	beforeDiffOutput := crmClusterStartDiffOutput{

--- a/pkg/operator/crmclusterstart_v1.go
+++ b/pkg/operator/crmclusterstart_v1.go
@@ -69,7 +69,7 @@ func WithCustomRetry(maxRetries int, initialDelay, maxDelay time.Duration, facto
 
 func NewCrmClusterStart(arguments Arguments,
 	operationID string,
-	options OperatorOptions[CrmClusterStart]) *Executor {
+	options Options[CrmClusterStart]) *Executor {
 	crmClusterStart := &CrmClusterStart{
 		baseOperator: newBaseOperator(
 			CrmClusterStartOperatorName, operationID, arguments, options.BaseOperatorOptions...,

--- a/pkg/operator/crmclusterstart_v1.go
+++ b/pkg/operator/crmclusterstart_v1.go
@@ -178,13 +178,19 @@ func (c *CrmClusterStart) operationDiff(_ context.Context) map[string]any {
 	beforeDiffOutput := crmClusterStartDiffOutput{
 		Started: beforeStarted,
 	}
-	before, _ := json.Marshal(beforeDiffOutput)
+	before, err := json.Marshal(beforeDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling before diff output: %v", err))
+	}
 	diff["before"] = string(before)
 
 	afterDiffOutput := crmClusterStartDiffOutput{
 		Started: afterStarted,
 	}
-	after, _ := json.Marshal(afterDiffOutput)
+	after, err := json.Marshal(afterDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling after diff output: %v", err))
+	}
 	diff["after"] = string(after)
 
 	return diff

--- a/pkg/operator/crmclusterstart_v1.go
+++ b/pkg/operator/crmclusterstart_v1.go
@@ -161,6 +161,9 @@ func (c *CrmClusterStart) verify(ctx context.Context) error {
 	return nil
 }
 
+//	operationDiff needs to be refactored, ignoring duplication issues for now
+//
+// nolint: dupl
 func (c *CrmClusterStart) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/pkg/operator/crmclusterstart_v1.go
+++ b/pkg/operator/crmclusterstart_v1.go
@@ -164,14 +164,25 @@ func (c *CrmClusterStart) verify(ctx context.Context) error {
 func (c *CrmClusterStart) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
+	beforeStarted, ok := c.resources[beforeDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid beforeStarted value: cannot parse '%s' to bool",
+			c.resources[beforeDiffField]))
+	}
+	afterStarted, ok := c.resources[afterDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid afterStarted value: cannot parse '%s' to bool",
+			c.resources[afterDiffField]))
+	}
+
 	beforeDiffOutput := crmClusterStartDiffOutput{
-		Started: c.resources[beforeDiffField].(bool),
+		Started: beforeStarted,
 	}
 	before, _ := json.Marshal(beforeDiffOutput)
 	diff["before"] = string(before)
 
 	afterDiffOutput := crmClusterStartDiffOutput{
-		Started: c.resources[afterDiffField].(bool),
+		Started: afterStarted,
 	}
 	after, _ := json.Marshal(afterDiffOutput)
 	diff["after"] = string(after)

--- a/pkg/operator/crmclusterstart_v1.go
+++ b/pkg/operator/crmclusterstart_v1.go
@@ -67,7 +67,7 @@ func WithCustomRetry(maxRetries int, initialDelay, maxDelay time.Duration, facto
 	}
 }
 
-func NewCrmClusterStart(arguments OperatorArguments,
+func NewCrmClusterStart(arguments Arguments,
 	operationID string,
 	options OperatorOptions[CrmClusterStart]) *Executor {
 	crmClusterStart := &CrmClusterStart{

--- a/pkg/operator/crmclusterstart_v1_test.go
+++ b/pkg/operator/crmclusterstart_v1_test.go
@@ -34,7 +34,7 @@ func (suite *CrmClusterStartOperatorTestSuite) TestCrmClusterStartClusterAlready
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.CrmClusterStart]{
+		operator.Options[operator.CrmClusterStart]{
 			OperatorOptions: []operator.Option[operator.CrmClusterStart]{
 				operator.Option[operator.CrmClusterStart](operator.WithCustomClusterClient(mockCrmClient)),
 			},
@@ -65,7 +65,7 @@ func (suite *CrmClusterStartOperatorTestSuite) TestCrmClusterStartClusterRollbac
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.CrmClusterStart]{
+		operator.Options[operator.CrmClusterStart]{
 			OperatorOptions: []operator.Option[operator.CrmClusterStart]{
 				operator.Option[operator.CrmClusterStart](operator.WithCustomClusterClient(mockCrmClient)),
 				operator.Option[operator.CrmClusterStart](operator.WithCustomRetry(2, 100*time.Millisecond, 1*time.Second, 1)),
@@ -93,7 +93,7 @@ func (suite *CrmClusterStartOperatorTestSuite) TestCrmClusterStartClusterRollbac
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.CrmClusterStart]{
+		operator.Options[operator.CrmClusterStart]{
 			OperatorOptions: []operator.Option[operator.CrmClusterStart]{
 				operator.Option[operator.CrmClusterStart](operator.WithCustomClusterClient(mockCrmClient)),
 				operator.Option[operator.CrmClusterStart](operator.WithCustomRetry(2, 100*time.Millisecond, 1*time.Second, 2)),
@@ -122,7 +122,7 @@ func (suite *CrmClusterStartOperatorTestSuite) TestCrmClusterStartClusterRollbac
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.CrmClusterStart]{
+		operator.Options[operator.CrmClusterStart]{
 			OperatorOptions: []operator.Option[operator.CrmClusterStart]{
 				operator.Option[operator.CrmClusterStart](operator.WithCustomClusterClient(mockCrmClient)),
 			},
@@ -151,7 +151,7 @@ func (suite *CrmClusterStartOperatorTestSuite) TestCrmClusterStartClusterStartVe
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.CrmClusterStart]{
+		operator.Options[operator.CrmClusterStart]{
 			OperatorOptions: []operator.Option[operator.CrmClusterStart]{
 				operator.Option[operator.CrmClusterStart](operator.WithCustomClusterClient(mockCrmClient)),
 				operator.Option[operator.CrmClusterStart](operator.WithCustomRetry(2, 100*time.Millisecond, 1*time.Second, 2)),
@@ -179,7 +179,7 @@ func (suite *CrmClusterStartOperatorTestSuite) TestCrmClusterStartClusterStartVe
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.CrmClusterStart]{
+		operator.Options[operator.CrmClusterStart]{
 			OperatorOptions: []operator.Option[operator.CrmClusterStart]{
 				operator.Option[operator.CrmClusterStart](operator.WithCustomClusterClient(mockCrmClient)),
 			},

--- a/pkg/operator/crmclusterstart_v1_test.go
+++ b/pkg/operator/crmclusterstart_v1_test.go
@@ -30,7 +30,7 @@ func (suite *CrmClusterStartOperatorTestSuite) TestCrmClusterStartClusterAlready
 	mockCrmClient.On("IsHostOnline", ctx).Return(true).Once()
 
 	crmClusterStartOperator := operator.NewCrmClusterStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
@@ -61,7 +61,7 @@ func (suite *CrmClusterStartOperatorTestSuite) TestCrmClusterStartClusterRollbac
 	mockCrmClient.On("StopCluster", ctx).Return(errors.New("failed to stop cluster"))
 
 	crmClusterStartOperator := operator.NewCrmClusterStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
@@ -89,7 +89,7 @@ func (suite *CrmClusterStartOperatorTestSuite) TestCrmClusterStartClusterRollbac
 	mockCrmClient.On("IsIdle", ctx).Return(false, nil)
 
 	crmClusterStartOperator := operator.NewCrmClusterStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
@@ -118,7 +118,7 @@ func (suite *CrmClusterStartOperatorTestSuite) TestCrmClusterStartClusterRollbac
 	mockCrmClient.On("StopCluster", ctx).Return(nil).Once()
 
 	crmClusterStartOperator := operator.NewCrmClusterStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
@@ -147,7 +147,7 @@ func (suite *CrmClusterStartOperatorTestSuite) TestCrmClusterStartClusterStartVe
 	mockCrmClient.On("StopCluster", ctx).Return(nil).Once()
 
 	crmClusterStartOperator := operator.NewCrmClusterStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
@@ -175,7 +175,7 @@ func (suite *CrmClusterStartOperatorTestSuite) TestCrmClusterStartClusterStartVe
 	mockCrmClient.On("IsHostOnline", ctx).Return(true)
 
 	crmClusterStartOperator := operator.NewCrmClusterStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",

--- a/pkg/operator/crmclusterstop_v1.go
+++ b/pkg/operator/crmclusterstop_v1.go
@@ -67,7 +67,7 @@ func WithCustomRetryStop(maxRetries int, initialDelay, maxDelay time.Duration, f
 	}
 }
 
-func NewCrmClusterStop(arguments OperatorArguments,
+func NewCrmClusterStop(arguments Arguments,
 	operationID string,
 	options OperatorOptions[CrmClusterStop]) *Executor {
 	crmClusterStop := &CrmClusterStop{

--- a/pkg/operator/crmclusterstop_v1.go
+++ b/pkg/operator/crmclusterstop_v1.go
@@ -175,13 +175,19 @@ func (c *CrmClusterStop) operationDiff(_ context.Context) map[string]any {
 	beforeDiffOutput := CrmClusterStopDiffOutput{
 		Stopped: beforeStopped,
 	}
-	before, _ := json.Marshal(beforeDiffOutput)
+	before, err := json.Marshal(beforeDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling before diff output: %v", err))
+	}
 	diff["before"] = string(before)
 
 	afterDiffOutput := CrmClusterStopDiffOutput{
 		Stopped: afterStopped,
 	}
-	after, _ := json.Marshal(afterDiffOutput)
+	after, err := json.Marshal(afterDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling after diff output: %v", err))
+	}
 	diff["after"] = string(after)
 
 	return diff

--- a/pkg/operator/crmclusterstop_v1.go
+++ b/pkg/operator/crmclusterstop_v1.go
@@ -69,7 +69,7 @@ func WithCustomRetryStop(maxRetries int, initialDelay, maxDelay time.Duration, f
 
 func NewCrmClusterStop(arguments Arguments,
 	operationID string,
-	options OperatorOptions[CrmClusterStop]) *Executor {
+	options Options[CrmClusterStop]) *Executor {
 	crmClusterStop := &CrmClusterStop{
 		baseOperator: newBaseOperator(
 			CrmClusterStopOperatorName, operationID, arguments, options.BaseOperatorOptions...,

--- a/pkg/operator/crmclusterstop_v1.go
+++ b/pkg/operator/crmclusterstop_v1.go
@@ -157,6 +157,9 @@ func (c *CrmClusterStop) verify(ctx context.Context) error {
 	return nil
 }
 
+//	operationDiff needs to be refactored, ignoring duplication issues for now
+//
+// nolint: dupl
 func (c *CrmClusterStop) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/pkg/operator/crmclusterstop_v1.go
+++ b/pkg/operator/crmclusterstop_v1.go
@@ -157,7 +157,7 @@ func (c *CrmClusterStop) verify(ctx context.Context) error {
 	return nil
 }
 
-func (c *CrmClusterStop) operationDiff(ctx context.Context) map[string]any {
+func (c *CrmClusterStop) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
 	beforeDiffOutput := CrmClusterStopDiffOutput{

--- a/pkg/operator/crmclusterstop_v1.go
+++ b/pkg/operator/crmclusterstop_v1.go
@@ -160,14 +160,26 @@ func (c *CrmClusterStop) verify(ctx context.Context) error {
 func (c *CrmClusterStop) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
+	beforeStopped, ok := c.resources[beforeDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid beforeStopped value: cannot parse '%s' to bool",
+			c.resources[beforeDiffField]))
+	}
+
+	afterStopped, ok := c.resources[afterDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid afterStopped value: cannot parse '%s' to bool",
+			c.resources[afterDiffField]))
+	}
+
 	beforeDiffOutput := CrmClusterStopDiffOutput{
-		Stopped: c.resources[beforeDiffField].(bool),
+		Stopped: beforeStopped,
 	}
 	before, _ := json.Marshal(beforeDiffOutput)
 	diff["before"] = string(before)
 
 	afterDiffOutput := CrmClusterStopDiffOutput{
-		Stopped: c.resources[afterDiffField].(bool),
+		Stopped: afterStopped,
 	}
 	after, _ := json.Marshal(afterDiffOutput)
 	diff["after"] = string(after)

--- a/pkg/operator/crmclusterstop_v1_test.go
+++ b/pkg/operator/crmclusterstop_v1_test.go
@@ -30,7 +30,7 @@ func (suite *CrmClusterStopOperatorTestSuite) TestCrmClusterStopClusterAlreadyOf
 	mockCrmClient.On("IsHostOnline", ctx).Return(false).Once()
 
 	crmClusterStopOperator := operator.NewCrmClusterStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
@@ -60,7 +60,7 @@ func (suite *CrmClusterStopOperatorTestSuite) TestCrmClusterStopClusterRollbackF
 	mockCrmClient.On("StartCluster", ctx).Return(errors.New("failed to start cluster"))
 
 	crmClusterStopOperator := operator.NewCrmClusterStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
@@ -89,7 +89,7 @@ func (suite *CrmClusterStopOperatorTestSuite) TestCrmClusterStopClusterRollbackS
 	mockCrmClient.On("StartCluster", ctx).Return(nil).Once()
 
 	crmClusterStopOperator := operator.NewCrmClusterStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
@@ -118,7 +118,7 @@ func (suite *CrmClusterStopOperatorTestSuite) TestCrmClusterStopClusterStartVeri
 	mockCrmClient.On("StartCluster", ctx).Return(nil).Once()
 
 	crmClusterStopOperator := operator.NewCrmClusterStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
@@ -147,7 +147,7 @@ func (suite *CrmClusterStopOperatorTestSuite) TestCrmClusterStopVerifySuccess() 
 	mockCrmClient.On("IsHostOnline", ctx).Return(false)
 
 	crmClusterStopOperator := operator.NewCrmClusterStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",

--- a/pkg/operator/crmclusterstop_v1_test.go
+++ b/pkg/operator/crmclusterstop_v1_test.go
@@ -34,7 +34,7 @@ func (suite *CrmClusterStopOperatorTestSuite) TestCrmClusterStopClusterAlreadyOf
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.CrmClusterStop]{
+		operator.Options[operator.CrmClusterStop]{
 			OperatorOptions: []operator.Option[operator.CrmClusterStop]{
 				operator.Option[operator.CrmClusterStop](operator.WithCustomClusterClientStop(mockCrmClient)),
 			},
@@ -64,7 +64,7 @@ func (suite *CrmClusterStopOperatorTestSuite) TestCrmClusterStopClusterRollbackF
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.CrmClusterStop]{
+		operator.Options[operator.CrmClusterStop]{
 			OperatorOptions: []operator.Option[operator.CrmClusterStop]{
 				operator.Option[operator.CrmClusterStop](operator.WithCustomClusterClientStop(mockCrmClient)),
 				operator.Option[operator.CrmClusterStop](operator.WithCustomRetryStop(2, 100*time.Millisecond, 1*time.Second, 1)),
@@ -93,7 +93,7 @@ func (suite *CrmClusterStopOperatorTestSuite) TestCrmClusterStopClusterRollbackS
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.CrmClusterStop]{
+		operator.Options[operator.CrmClusterStop]{
 			OperatorOptions: []operator.Option[operator.CrmClusterStop]{
 				operator.Option[operator.CrmClusterStop](operator.WithCustomClusterClientStop(mockCrmClient)),
 			},
@@ -122,7 +122,7 @@ func (suite *CrmClusterStopOperatorTestSuite) TestCrmClusterStopClusterStartVeri
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.CrmClusterStop]{
+		operator.Options[operator.CrmClusterStop]{
 			OperatorOptions: []operator.Option[operator.CrmClusterStop]{
 				operator.Option[operator.CrmClusterStop](operator.WithCustomClusterClientStop(mockCrmClient)),
 				operator.Option[operator.CrmClusterStop](operator.WithCustomRetryStop(2, 100*time.Millisecond, 1*time.Second, 2)),
@@ -151,7 +151,7 @@ func (suite *CrmClusterStopOperatorTestSuite) TestCrmClusterStopVerifySuccess() 
 			"cluster_id": "test-cluster-id",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.CrmClusterStop]{
+		operator.Options[operator.CrmClusterStop]{
 			OperatorOptions: []operator.Option[operator.CrmClusterStop]{
 				operator.Option[operator.CrmClusterStop](operator.WithCustomClusterClientStop(mockCrmClient)),
 			},

--- a/pkg/operator/execution.go
+++ b/pkg/operator/execution.go
@@ -5,7 +5,7 @@ import (
 )
 
 type ExecutionError struct {
-	ErrorPhase OPERATION_PHASES
+	ErrorPhase OperatorPhases
 	Message    string
 }
 
@@ -19,7 +19,7 @@ func (e ExecutionError) Error() string {
 
 type ExecutionSuccess struct {
 	Diff      map[string]any
-	LastPhase OPERATION_PHASES
+	LastPhase OperatorPhases
 }
 
 type ExecutionReport struct {
@@ -28,7 +28,7 @@ type ExecutionReport struct {
 	Error       *ExecutionError
 }
 
-func executionReportWithError(error error, phase OPERATION_PHASES, operationID string) *ExecutionReport {
+func executionReportWithError(error error, phase OperatorPhases, operationID string) *ExecutionReport {
 	return &ExecutionReport{
 		OperationID: operationID,
 		Error: &ExecutionError{
@@ -38,7 +38,7 @@ func executionReportWithError(error error, phase OPERATION_PHASES, operationID s
 	}
 }
 
-func executionReportWithSuccess(diff map[string]any, phase OPERATION_PHASES, operationID string) *ExecutionReport {
+func executionReportWithSuccess(diff map[string]any, phase OperatorPhases, operationID string) *ExecutionReport {
 	return &ExecutionReport{
 		OperationID: operationID,
 		Success: &ExecutionSuccess{

--- a/pkg/operator/execution.go
+++ b/pkg/operator/execution.go
@@ -5,7 +5,7 @@ import (
 )
 
 type ExecutionError struct {
-	ErrorPhase OperatorPhases
+	ErrorPhase PhaseName
 	Message    string
 }
 
@@ -19,7 +19,7 @@ func (e ExecutionError) Error() string {
 
 type ExecutionSuccess struct {
 	Diff      map[string]any
-	LastPhase OperatorPhases
+	LastPhase PhaseName
 }
 
 type ExecutionReport struct {
@@ -28,7 +28,7 @@ type ExecutionReport struct {
 	Error       *ExecutionError
 }
 
-func executionReportWithError(error error, phase OperatorPhases, operationID string) *ExecutionReport {
+func executionReportWithError(error error, phase PhaseName, operationID string) *ExecutionReport {
 	return &ExecutionReport{
 		OperationID: operationID,
 		Error: &ExecutionError{
@@ -38,7 +38,7 @@ func executionReportWithError(error error, phase OperatorPhases, operationID str
 	}
 }
 
-func executionReportWithSuccess(diff map[string]any, phase OperatorPhases, operationID string) *ExecutionReport {
+func executionReportWithSuccess(diff map[string]any, phase PhaseName, operationID string) *ExecutionReport {
 	return &ExecutionReport{
 		OperationID: operationID,
 		Success: &ExecutionSuccess{

--- a/pkg/operator/execution.go
+++ b/pkg/operator/execution.go
@@ -28,11 +28,11 @@ type ExecutionReport struct {
 	Error       *ExecutionError
 }
 
-func executionReportWithError(error error, phase PhaseName, operationID string) *ExecutionReport {
+func executionReportWithError(err error, phase PhaseName, operationID string) *ExecutionReport {
 	return &ExecutionReport{
 		OperationID: operationID,
 		Error: &ExecutionError{
-			Message:    error.Error(),
+			Message:    err.Error(),
 			ErrorPhase: phase,
 		},
 	}

--- a/pkg/operator/executor.go
+++ b/pkg/operator/executor.go
@@ -16,7 +16,7 @@ type phaser interface {
 }
 
 type Executor struct {
-	currentPhase OPERATION_PHASES
+	currentPhase OperatorPhases
 	phaser       phaser
 	operationID  string
 	logger       *slog.Logger

--- a/pkg/operator/executor.go
+++ b/pkg/operator/executor.go
@@ -29,6 +29,18 @@ const (
 	FAILURE = "FAILURE"
 )
 
+func NewExecutor(phaser phaser, operationID string, logger *slog.Logger) *Executor {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Executor{
+		currentPhase: PLAN,
+		phaser:       phaser,
+		operationID:  operationID,
+		logger:       logger,
+	}
+}
+
 func (e *Executor) Run(ctx context.Context) *ExecutionReport {
 	e.currentPhase = PLAN
 	e.logger.Info(RUN, "phase", e.currentPhase, "event", BEGIN)

--- a/pkg/operator/executor.go
+++ b/pkg/operator/executor.go
@@ -16,7 +16,7 @@ type phaser interface {
 }
 
 type Executor struct {
-	currentPhase OperatorPhases
+	currentPhase PhaseName
 	phaser       phaser
 	operationID  string
 	logger       *slog.Logger

--- a/pkg/operator/executor_test.go
+++ b/pkg/operator/executor_test.go
@@ -34,11 +34,7 @@ func TestExecutorHappyFlow(t *testing.T) {
 		Once().
 		NotBefore(operationDiffCall)
 
-	executor := Executor{
-		phaser:      phaser,
-		operationID: "operation-id",
-		logger:      slog.Default(),
-	}
+	executor := NewExecutor(phaser, "operation-id", slog.Default())
 
 	report := executor.Run(executionContext)
 
@@ -58,11 +54,7 @@ func TestExecutorPlanError(t *testing.T) {
 
 	phaser.AssertNotCalled(t, "after", executionContext)
 
-	executor := Executor{
-		phaser:      phaser,
-		operationID: "operation-id",
-		logger:      slog.Default(),
-	}
+	executor := NewExecutor(phaser, "operation-id", slog.Default())
 
 	report := executor.Run(executionContext)
 
@@ -88,11 +80,7 @@ func TestExecutorPlanAlreadyApplied(t *testing.T) {
 		Once().
 		NotBefore(operationDiffCall)
 
-	executor := Executor{
-		phaser:      phaser,
-		operationID: "operation-id",
-		logger:      slog.Default(),
-	}
+	executor := NewExecutor(phaser, "operation-id", slog.Default())
 
 	report := executor.Run(executionContext)
 
@@ -123,11 +111,7 @@ func TestExecutorCommitErrorWithSuccessfulRollback(t *testing.T) {
 		Once().
 		NotBefore(rollbackCall)
 
-	executor := Executor{
-		phaser:      phaser,
-		operationID: "operation-id",
-		logger:      slog.Default(),
-	}
+	executor := NewExecutor(phaser, "operation-id", slog.Default())
 
 	report := executor.Run(executionContext)
 
@@ -158,11 +142,7 @@ func TestExecutorCommitErrorWithFailedRollback(t *testing.T) {
 		Once().
 		NotBefore(rollbackCall)
 
-	executor := Executor{
-		phaser:      phaser,
-		operationID: "operation-id",
-		logger:      slog.Default(),
-	}
+	executor := NewExecutor(phaser, "operation-id", slog.Default())
 
 	report := executor.Run(executionContext)
 
@@ -196,11 +176,7 @@ func TestExecutorVerifyErrorWithSuccessfulRollback(t *testing.T) {
 		Once().
 		NotBefore(rollbackCall)
 
-	executor := Executor{
-		phaser:      phaser,
-		operationID: "operation-id",
-		logger:      slog.Default(),
-	}
+	executor := NewExecutor(phaser, "operation-id", slog.Default())
 
 	report := executor.Run(executionContext)
 
@@ -235,11 +211,7 @@ func TestExecutorVerifyErrorWithFailedRollback(t *testing.T) {
 		Once().
 		NotBefore(rollbackCall)
 
-	executor := Executor{
-		phaser:      phaser,
-		operationID: "operation-id",
-		logger:      slog.Default(),
-	}
+	executor := NewExecutor(phaser, "operation-id", slog.Default())
 
 	report := executor.Run(executionContext)
 

--- a/pkg/operator/executor_test.go
+++ b/pkg/operator/executor_test.go
@@ -1,4 +1,4 @@
-package operator
+package operator_test
 
 import (
 	"context"
@@ -7,11 +7,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	operator "github.com/trento-project/workbench/pkg/operator"
 )
 
 func TestExecutorHappyFlow(t *testing.T) {
 	executionContext := context.Background()
-	phaser := NewMockphaser(t)
+	phaser := operator.NewMockphaser(t)
 	emptyDiff := make(map[string]any)
 
 	planCall := phaser.On("plan", executionContext).
@@ -34,19 +35,19 @@ func TestExecutorHappyFlow(t *testing.T) {
 		Once().
 		NotBefore(operationDiffCall)
 
-	executor := NewExecutor(phaser, "operation-id", slog.Default())
+	executor := operator.NewExecutor(phaser, "operation-id", slog.Default())
 
 	report := executor.Run(executionContext)
 
 	assert.Equal(t, "operation-id", report.OperationID)
-	assert.Equal(t, VERIFY, report.Success.LastPhase)
+	assert.Equal(t, operator.VERIFY, report.Success.LastPhase)
 	assert.Equal(t, emptyDiff, report.Success.Diff)
 	assert.Nil(t, report.Error)
 }
 
 func TestExecutorPlanError(t *testing.T) {
 	executionContext := context.Background()
-	phaser := NewMockphaser(t)
+	phaser := operator.NewMockphaser(t)
 	planError := errors.New("error during plan phase")
 
 	phaser.On("plan", executionContext).
@@ -54,18 +55,18 @@ func TestExecutorPlanError(t *testing.T) {
 
 	phaser.AssertNotCalled(t, "after", executionContext)
 
-	executor := NewExecutor(phaser, "operation-id", slog.Default())
+	executor := operator.NewExecutor(phaser, "operation-id", slog.Default())
 
 	report := executor.Run(executionContext)
 
 	assert.Equal(t, planError.Error(), report.Error.Message)
-	assert.Equal(t, PLAN, report.Error.ErrorPhase)
+	assert.Equal(t, operator.PLAN, report.Error.ErrorPhase)
 	assert.Nil(t, report.Success)
 }
 
 func TestExecutorPlanAlreadyApplied(t *testing.T) {
 	executionContext := context.Background()
-	phaser := NewMockphaser(t)
+	phaser := operator.NewMockphaser(t)
 	emptyDiff := make(map[string]any)
 
 	planCall := phaser.On("plan", executionContext).
@@ -80,19 +81,19 @@ func TestExecutorPlanAlreadyApplied(t *testing.T) {
 		Once().
 		NotBefore(operationDiffCall)
 
-	executor := NewExecutor(phaser, "operation-id", slog.Default())
+	executor := operator.NewExecutor(phaser, "operation-id", slog.Default())
 
 	report := executor.Run(executionContext)
 
 	assert.Equal(t, "operation-id", report.OperationID)
-	assert.Equal(t, PLAN, report.Success.LastPhase)
+	assert.Equal(t, operator.PLAN, report.Success.LastPhase)
 	assert.Equal(t, emptyDiff, report.Success.Diff)
 	assert.Nil(t, report.Error)
 }
 
 func TestExecutorCommitErrorWithSuccessfulRollback(t *testing.T) {
 	executionContext := context.Background()
-	phaser := NewMockphaser(t)
+	phaser := operator.NewMockphaser(t)
 	commitError := errors.New("error during error phase")
 
 	planCall := phaser.On("plan", executionContext).
@@ -111,18 +112,18 @@ func TestExecutorCommitErrorWithSuccessfulRollback(t *testing.T) {
 		Once().
 		NotBefore(rollbackCall)
 
-	executor := NewExecutor(phaser, "operation-id", slog.Default())
+	executor := operator.NewExecutor(phaser, "operation-id", slog.Default())
 
 	report := executor.Run(executionContext)
 
 	assert.Equal(t, commitError.Error(), report.Error.Message)
-	assert.Equal(t, COMMIT, report.Error.ErrorPhase)
+	assert.Equal(t, operator.COMMIT, report.Error.ErrorPhase)
 	assert.Nil(t, report.Success)
 }
 
 func TestExecutorCommitErrorWithFailedRollback(t *testing.T) {
 	executionContext := context.Background()
-	phaser := NewMockphaser(t)
+	phaser := operator.NewMockphaser(t)
 	commitError := errors.New("error during error phase")
 	rollbackError := errors.New("error during rollback phase")
 
@@ -142,18 +143,18 @@ func TestExecutorCommitErrorWithFailedRollback(t *testing.T) {
 		Once().
 		NotBefore(rollbackCall)
 
-	executor := NewExecutor(phaser, "operation-id", slog.Default())
+	executor := operator.NewExecutor(phaser, "operation-id", slog.Default())
 
 	report := executor.Run(executionContext)
 
 	assert.Equal(t, errors.Join(rollbackError, commitError).Error(), report.Error.Message)
-	assert.Equal(t, ROLLBACK, report.Error.ErrorPhase)
+	assert.Equal(t, operator.ROLLBACK, report.Error.ErrorPhase)
 	assert.Nil(t, report.Success)
 }
 
 func TestExecutorVerifyErrorWithSuccessfulRollback(t *testing.T) {
 	executionContext := context.Background()
-	phaser := NewMockphaser(t)
+	phaser := operator.NewMockphaser(t)
 	verifyError := errors.New("error during verify phase")
 
 	planCall := phaser.On("plan", executionContext).
@@ -176,18 +177,18 @@ func TestExecutorVerifyErrorWithSuccessfulRollback(t *testing.T) {
 		Once().
 		NotBefore(rollbackCall)
 
-	executor := NewExecutor(phaser, "operation-id", slog.Default())
+	executor := operator.NewExecutor(phaser, "operation-id", slog.Default())
 
 	report := executor.Run(executionContext)
 
 	assert.Equal(t, verifyError.Error(), report.Error.Message)
-	assert.Equal(t, VERIFY, report.Error.ErrorPhase)
+	assert.Equal(t, operator.VERIFY, report.Error.ErrorPhase)
 	assert.Nil(t, report.Success)
 }
 
 func TestExecutorVerifyErrorWithFailedRollback(t *testing.T) {
 	executionContext := context.Background()
-	phaser := NewMockphaser(t)
+	phaser := operator.NewMockphaser(t)
 	verifyError := errors.New("error during verify phase")
 	rollbackError := errors.New("error during rollback phase")
 
@@ -211,11 +212,11 @@ func TestExecutorVerifyErrorWithFailedRollback(t *testing.T) {
 		Once().
 		NotBefore(rollbackCall)
 
-	executor := NewExecutor(phaser, "operation-id", slog.Default())
+	executor := operator.NewExecutor(phaser, "operation-id", slog.Default())
 
 	report := executor.Run(executionContext)
 
 	assert.Equal(t, errors.Join(rollbackError, verifyError).Error(), report.Error.Message)
-	assert.Equal(t, ROLLBACK, report.Error.ErrorPhase)
+	assert.Equal(t, operator.ROLLBACK, report.Error.ErrorPhase)
 	assert.Nil(t, report.Success)
 }

--- a/pkg/operator/hostreboot_v1.go
+++ b/pkg/operator/hostreboot_v1.go
@@ -217,32 +217,32 @@ func (h *HostReboot) isRebootScheduled(ctx context.Context) (bool, error) {
 	}
 
 	// Check for systemd-shutdown processes
-	return h.hasActiveShutdownProcess(ctx)
+	return h.hasActiveShutdownProcess(ctx), nil
 }
 
 // hasActiveShutdownProcess checks if there are any active shutdown processes
 // This is a fallback method to detect scheduled shutdowns
-func (h *HostReboot) hasActiveShutdownProcess(ctx context.Context) (bool, error) {
+func (h *HostReboot) hasActiveShutdownProcess(ctx context.Context) bool {
 	// Check if shutdown command is running or if there's a scheduled shutdown
 	_, err := h.executor.Exec(ctx, "pgrep", "-f", "shutdown")
 	if err == nil {
 		h.logger.Debug("Found active shutdown process")
-		return true, nil
+		return true
 	}
 
 	// Check for systemd-shutdown
 	_, err = h.executor.Exec(ctx, "pgrep", "-f", "systemd-shutdown")
 	if err == nil {
 		h.logger.Debug("Found systemd-shutdown process")
-		return true, nil
+		return true
 	}
 
 	// Check if there's a /run/systemd/shutdown/scheduled file
 	_, err = h.executor.Exec(ctx, "test", "-f", "/run/systemd/shutdown/scheduled")
 	if err == nil {
 		h.logger.Debug("Found systemd shutdown scheduled file")
-		return true, nil
+		return true
 	}
 
-	return false, nil
+	return false
 }

--- a/pkg/operator/hostreboot_v1.go
+++ b/pkg/operator/hostreboot_v1.go
@@ -62,7 +62,7 @@ func WithCustomDbusConstructor(constructor func(ctx context.Context) (dbus.DbusC
 
 func WithStaticDbusConnector(connector dbus.DbusConnector) HostRebootOption {
 	return func(o *HostReboot) {
-		o.dbusConstructor = func(ctx context.Context) (dbus.DbusConnector, error) {
+		o.dbusConstructor = func(_ context.Context) (dbus.DbusConnector, error) {
 			return connector, nil
 		}
 	}
@@ -141,7 +141,7 @@ func (h *HostReboot) verify(ctx context.Context) error {
 	return nil
 }
 
-func (h *HostReboot) operationDiff(ctx context.Context) map[string]any {
+func (h *HostReboot) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
 	beforeDiffOutput := hostRebootDiffOutput{

--- a/pkg/operator/hostreboot_v1.go
+++ b/pkg/operator/hostreboot_v1.go
@@ -76,7 +76,7 @@ func defaultDbusConstructor(ctx context.Context) (dbus.Connector, error) {
 	return connector, nil
 }
 
-func NewHostReboot(arguments OperatorArguments,
+func NewHostReboot(arguments Arguments,
 	operationID string,
 	options OperatorOptions[HostReboot]) *Executor {
 	hostReboot := &HostReboot{

--- a/pkg/operator/hostreboot_v1.go
+++ b/pkg/operator/hostreboot_v1.go
@@ -144,15 +144,25 @@ func (h *HostReboot) verify(ctx context.Context) error {
 func (h *HostReboot) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
+	beforeScheduled, ok := h.resources[beforeDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid beforeScheduled value: cannot parse '%s' to bool",
+			h.resources[beforeDiffField]))
+	}
+
 	beforeDiffOutput := hostRebootDiffOutput{
-		Scheduled: h.resources[beforeDiffField].(bool),
+		Scheduled: beforeScheduled,
 	}
 	before, _ := json.Marshal(beforeDiffOutput)
 	diff["before"] = string(before)
 
 	afterScheduled := false
 	if after, exists := h.resources[afterDiffField]; exists {
-		afterScheduled = after.(bool)
+		afterScheduled, ok = after.(bool)
+		if !ok {
+			panic(fmt.Sprintf("invalid afterScheduled value: cannot parse '%s' to bool",
+				h.resources[afterDiffField]))
+		}
 	}
 
 	afterDiffOutput := hostRebootDiffOutput{

--- a/pkg/operator/hostreboot_v1.go
+++ b/pkg/operator/hostreboot_v1.go
@@ -39,7 +39,7 @@ const (
 type HostReboot struct {
 	baseOperator
 	executor        support.CmdExecutor
-	dbusConstructor func(ctx context.Context) (dbus.DbusConnector, error)
+	dbusConstructor func(ctx context.Context) (dbus.Connector, error)
 }
 
 type HostRebootOption Option[HostReboot]
@@ -54,22 +54,22 @@ func WithCustomHostRebootExecutor(executor support.CmdExecutor) HostRebootOption
 	}
 }
 
-func WithCustomDbusConstructor(constructor func(ctx context.Context) (dbus.DbusConnector, error)) HostRebootOption {
+func WithCustomDbusConstructor(constructor func(ctx context.Context) (dbus.Connector, error)) HostRebootOption {
 	return func(o *HostReboot) {
 		o.dbusConstructor = constructor
 	}
 }
 
-func WithStaticDbusConnector(connector dbus.DbusConnector) HostRebootOption {
+func WithStaticDbusConnector(connector dbus.Connector) HostRebootOption {
 	return func(o *HostReboot) {
-		o.dbusConstructor = func(_ context.Context) (dbus.DbusConnector, error) {
+		o.dbusConstructor = func(_ context.Context) (dbus.Connector, error) {
 			return connector, nil
 		}
 	}
 }
 
-func defaultDbusConstructor(ctx context.Context) (dbus.DbusConnector, error) {
-	connector, err := dbus.NewDbusConnector(ctx)
+func defaultDbusConstructor(ctx context.Context) (dbus.Connector, error) {
+	connector, err := dbus.NewConnector(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create D-Bus connector: %w", err)
 	}

--- a/pkg/operator/hostreboot_v1.go
+++ b/pkg/operator/hostreboot_v1.go
@@ -78,7 +78,7 @@ func defaultDbusConstructor(ctx context.Context) (dbus.Connector, error) {
 
 func NewHostReboot(arguments Arguments,
 	operationID string,
-	options OperatorOptions[HostReboot]) *Executor {
+	options Options[HostReboot]) *Executor {
 	hostReboot := &HostReboot{
 		baseOperator: newBaseOperator(
 			HostRebootOperatorName, operationID, arguments, options.BaseOperatorOptions...,

--- a/pkg/operator/hostreboot_v1.go
+++ b/pkg/operator/hostreboot_v1.go
@@ -153,7 +153,10 @@ func (h *HostReboot) operationDiff(_ context.Context) map[string]any {
 	beforeDiffOutput := hostRebootDiffOutput{
 		Scheduled: beforeScheduled,
 	}
-	before, _ := json.Marshal(beforeDiffOutput)
+	before, err := json.Marshal(beforeDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling before diff output: %v", err))
+	}
 	diff["before"] = string(before)
 
 	afterScheduled := false
@@ -168,7 +171,10 @@ func (h *HostReboot) operationDiff(_ context.Context) map[string]any {
 	afterDiffOutput := hostRebootDiffOutput{
 		Scheduled: afterScheduled,
 	}
-	after, _ := json.Marshal(afterDiffOutput)
+	after, err := json.Marshal(afterDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling after diff output: %v", err))
+	}
 	diff["after"] = string(after)
 
 	return diff

--- a/pkg/operator/hostreboot_v1_test.go
+++ b/pkg/operator/hostreboot_v1_test.go
@@ -149,7 +149,7 @@ func (suite *HostRebootOperatorTestSuite) TestHostRebootOperatorAlreadyScheduled
 func (suite *HostRebootOperatorTestSuite) TestHostRebootOperatorDbusConnectionError() {
 	ctx := context.Background()
 
-	failingConstructor := func(_ context.Context) (dbus.DbusConnector, error) {
+	failingConstructor := func(_ context.Context) (dbus.Connector, error) {
 		return nil, errors.New("dbus constructor failure")
 	}
 

--- a/pkg/operator/hostreboot_v1_test.go
+++ b/pkg/operator/hostreboot_v1_test.go
@@ -26,7 +26,7 @@ func buildHostRebootOperator(suite *HostRebootOperatorTestSuite,
 	mockDbusConnector *dbusMocks.MockDbusConnector,
 ) *operator.Executor {
 	return operator.NewHostReboot(
-		operator.OperatorArguments{},
+		operator.Arguments{},
 		"test-op",
 		operator.OperatorOptions[operator.HostReboot]{
 			BaseOperatorOptions: []operator.BaseOperatorOption{
@@ -154,7 +154,7 @@ func (suite *HostRebootOperatorTestSuite) TestHostRebootOperatorDbusConnectionEr
 	}
 
 	report := operator.NewHostReboot(
-		operator.OperatorArguments{},
+		operator.Arguments{},
 		"test-op",
 		operator.OperatorOptions[operator.HostReboot]{
 			BaseOperatorOptions: []operator.BaseOperatorOption{

--- a/pkg/operator/hostreboot_v1_test.go
+++ b/pkg/operator/hostreboot_v1_test.go
@@ -28,7 +28,7 @@ func buildHostRebootOperator(suite *HostRebootOperatorTestSuite,
 	return operator.NewHostReboot(
 		operator.Arguments{},
 		"test-op",
-		operator.OperatorOptions[operator.HostReboot]{
+		operator.Options[operator.HostReboot]{
 			BaseOperatorOptions: []operator.BaseOperatorOption{
 				operator.WithCustomLogger(suite.logger),
 			},
@@ -156,7 +156,7 @@ func (suite *HostRebootOperatorTestSuite) TestHostRebootOperatorDbusConnectionEr
 	report := operator.NewHostReboot(
 		operator.Arguments{},
 		"test-op",
-		operator.OperatorOptions[operator.HostReboot]{
+		operator.Options[operator.HostReboot]{
 			BaseOperatorOptions: []operator.BaseOperatorOption{
 				operator.WithCustomLogger(suite.logger),
 			},

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -4,16 +4,16 @@ import (
 	"context"
 )
 
-type OPERATION_PHASES string
+type OperatorPhases string
 
 type OperatorArguments map[string]any
 type Option[T any] func(*T)
 
 const (
-	PLAN     OPERATION_PHASES = "PLAN"
-	COMMIT   OPERATION_PHASES = "COMMIT"
-	VERIFY   OPERATION_PHASES = "VERIFY"
-	ROLLBACK OPERATION_PHASES = "ROLLBACK"
+	PLAN     OperatorPhases = "PLAN"
+	COMMIT   OperatorPhases = "COMMIT"
+	VERIFY   OperatorPhases = "VERIFY"
+	ROLLBACK OperatorPhases = "ROLLBACK"
 )
 
 type Operator interface {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -6,7 +6,7 @@ import (
 
 type PhaseName string
 
-type OperatorArguments map[string]any
+type Arguments map[string]any
 type Option[T any] func(*T)
 
 const (

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -4,16 +4,16 @@ import (
 	"context"
 )
 
-type OperatorPhases string
+type PhaseName string
 
 type OperatorArguments map[string]any
 type Option[T any] func(*T)
 
 const (
-	PLAN     OperatorPhases = "PLAN"
-	COMMIT   OperatorPhases = "COMMIT"
-	VERIFY   OperatorPhases = "VERIFY"
-	ROLLBACK OperatorPhases = "ROLLBACK"
+	PLAN     PhaseName = "PLAN"
+	COMMIT   PhaseName = "COMMIT"
+	VERIFY   PhaseName = "VERIFY"
+	ROLLBACK PhaseName = "ROLLBACK"
 )
 
 type Operator interface {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -20,7 +20,7 @@ type Operator interface {
 	Run(ctx context.Context) *ExecutionReport
 }
 
-type OperatorOptions[T any] struct {
+type Options[T any] struct {
 	BaseOperatorOptions []BaseOperatorOption
 	OperatorOptions     []Option[T]
 }

--- a/pkg/operator/registry.go
+++ b/pkg/operator/registry.go
@@ -17,7 +17,7 @@ func (e *NotFoundError) Error() string {
 type Builder func(operationID string, arguments Arguments) Operator
 
 // map[operatorName]map[operatorVersion]OperatorBuilder
-type OperatorBuildersTree map[string]map[string]Builder
+type BuildersTree map[string]map[string]Builder
 
 func extractOperatorNameAndVersion(operatorName string) (string, string, error) {
 	parts := strings.Split(operatorName, "@")
@@ -35,10 +35,10 @@ func extractOperatorNameAndVersion(operatorName string) (string, string, error) 
 }
 
 type Registry struct {
-	operators OperatorBuildersTree
+	operators BuildersTree
 }
 
-func NewRegistry(operators OperatorBuildersTree) *Registry {
+func NewRegistry(operators BuildersTree) *Registry {
 	return &Registry{
 		operators: operators,
 	}
@@ -98,7 +98,7 @@ func (m *Registry) getLatestVersionForOperator(name string) (string, error) {
 
 func StandardRegistry(options ...BaseOperatorOption) *Registry {
 	return &Registry{
-		operators: OperatorBuildersTree{
+		operators: BuildersTree{
 			ClusterMaintenanceChangeOperatorName: map[string]Builder{
 				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewClusterMaintenanceChange(arguments, operationID, Options[ClusterMaintenanceChange]{

--- a/pkg/operator/registry.go
+++ b/pkg/operator/registry.go
@@ -101,7 +101,7 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 		operators: OperatorBuildersTree{
 			ClusterMaintenanceChangeOperatorName: map[string]OperatorBuilder{
 				"v1": func(operationID string, arguments Arguments) Operator {
-					return NewClusterMaintenanceChange(arguments, operationID, OperatorOptions[ClusterMaintenanceChange]{
+					return NewClusterMaintenanceChange(arguments, operationID, Options[ClusterMaintenanceChange]{
 						BaseOperatorOptions: options,
 					})
 				},
@@ -109,7 +109,7 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 
 			CrmClusterStartOperatorName: map[string]OperatorBuilder{
 				"v1": func(operationID string, arguments Arguments) Operator {
-					return NewCrmClusterStart(arguments, operationID, OperatorOptions[CrmClusterStart]{
+					return NewCrmClusterStart(arguments, operationID, Options[CrmClusterStart]{
 						BaseOperatorOptions: options,
 					})
 				},
@@ -117,7 +117,7 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 
 			CrmClusterStopOperatorName: map[string]OperatorBuilder{
 				"v1": func(operationID string, arguments Arguments) Operator {
-					return NewCrmClusterStop(arguments, operationID, OperatorOptions[CrmClusterStop]{
+					return NewCrmClusterStop(arguments, operationID, Options[CrmClusterStop]{
 						BaseOperatorOptions: options,
 					})
 				},
@@ -125,7 +125,7 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 
 			HostRebootOperatorName: map[string]OperatorBuilder{
 				"v1": func(operationID string, arguments Arguments) Operator {
-					return NewHostReboot(arguments, operationID, OperatorOptions[HostReboot]{
+					return NewHostReboot(arguments, operationID, Options[HostReboot]{
 						BaseOperatorOptions: options,
 					})
 				},
@@ -133,49 +133,49 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 
 			SapInstanceStartOperatorName: map[string]OperatorBuilder{
 				"v1": func(operationID string, arguments Arguments) Operator {
-					return NewSAPInstanceStart(arguments, operationID, OperatorOptions[SAPInstanceStart]{
+					return NewSAPInstanceStart(arguments, operationID, Options[SAPInstanceStart]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
 			SapInstanceStopOperatorName: map[string]OperatorBuilder{
 				"v1": func(operationID string, arguments Arguments) Operator {
-					return NewSAPInstanceStop(arguments, operationID, OperatorOptions[SAPInstanceStop]{
+					return NewSAPInstanceStop(arguments, operationID, Options[SAPInstanceStop]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
 			SapSystemStartOperatorName: map[string]OperatorBuilder{
 				"v1": func(operationID string, arguments Arguments) Operator {
-					return NewSAPSystemStart(arguments, operationID, OperatorOptions[SAPSystemStart]{
+					return NewSAPSystemStart(arguments, operationID, Options[SAPSystemStart]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
 			SapSystemStopOperatorName: map[string]OperatorBuilder{
 				"v1": func(operationID string, arguments Arguments) Operator {
-					return NewSAPSystemStop(arguments, operationID, OperatorOptions[SAPSystemStop]{
+					return NewSAPSystemStop(arguments, operationID, Options[SAPSystemStop]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
 			SaptuneApplySolutionOperatorName: map[string]OperatorBuilder{
 				"v1": func(operationID string, arguments Arguments) Operator {
-					return NewSaptuneApplySolution(arguments, operationID, OperatorOptions[SaptuneApplySolution]{
+					return NewSaptuneApplySolution(arguments, operationID, Options[SaptuneApplySolution]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
 			SaptuneChangeSolutionOperatorName: map[string]OperatorBuilder{
 				"v1": func(operationID string, arguments Arguments) Operator {
-					return NewSaptuneChangeSolution(arguments, operationID, OperatorOptions[SaptuneChangeSolution]{
+					return NewSaptuneChangeSolution(arguments, operationID, Options[SaptuneChangeSolution]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
 			PacemakerEnableOperatorName: map[string]OperatorBuilder{
 				"v1": func(operationID string, arguments Arguments) Operator {
-					return NewServiceEnable(PacemakerEnableOperatorName, arguments, operationID, OperatorOptions[ServiceEnable]{
+					return NewServiceEnable(PacemakerEnableOperatorName, arguments, operationID, Options[ServiceEnable]{
 						BaseOperatorOptions: options,
 						OperatorOptions: []Option[ServiceEnable]{
 							Option[ServiceEnable](WithServiceToEnable(pacemakerServiceName)),
@@ -185,7 +185,7 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 			},
 			PacemakerDisableOperatorName: map[string]OperatorBuilder{
 				"v1": func(operationID string, arguments Arguments) Operator {
-					return NewServiceDisable(PacemakerDisableOperatorName, arguments, operationID, OperatorOptions[ServiceDisable]{
+					return NewServiceDisable(PacemakerDisableOperatorName, arguments, operationID, Options[ServiceDisable]{
 						BaseOperatorOptions: options,
 						OperatorOptions: []Option[ServiceDisable]{
 							Option[ServiceDisable](WithServiceToDisable(pacemakerServiceName)),

--- a/pkg/operator/registry.go
+++ b/pkg/operator/registry.go
@@ -14,7 +14,7 @@ func (e *OperatorNotFoundError) Error() string {
 	return fmt.Sprintf("operator %s not found", e.Name)
 }
 
-type OperatorBuilder func(operationID string, arguments OperatorArguments) Operator
+type OperatorBuilder func(operationID string, arguments Arguments) Operator
 
 // map[operatorName]map[operatorVersion]OperatorBuilder
 type OperatorBuildersTree map[string]map[string]OperatorBuilder
@@ -100,7 +100,7 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 	return &Registry{
 		operators: OperatorBuildersTree{
 			ClusterMaintenanceChangeOperatorName: map[string]OperatorBuilder{
-				"v1": func(operationID string, arguments OperatorArguments) Operator {
+				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewClusterMaintenanceChange(arguments, operationID, OperatorOptions[ClusterMaintenanceChange]{
 						BaseOperatorOptions: options,
 					})
@@ -108,7 +108,7 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 			},
 
 			CrmClusterStartOperatorName: map[string]OperatorBuilder{
-				"v1": func(operationID string, arguments OperatorArguments) Operator {
+				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewCrmClusterStart(arguments, operationID, OperatorOptions[CrmClusterStart]{
 						BaseOperatorOptions: options,
 					})
@@ -116,7 +116,7 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 			},
 
 			CrmClusterStopOperatorName: map[string]OperatorBuilder{
-				"v1": func(operationID string, arguments OperatorArguments) Operator {
+				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewCrmClusterStop(arguments, operationID, OperatorOptions[CrmClusterStop]{
 						BaseOperatorOptions: options,
 					})
@@ -124,7 +124,7 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 			},
 
 			HostRebootOperatorName: map[string]OperatorBuilder{
-				"v1": func(operationID string, arguments OperatorArguments) Operator {
+				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewHostReboot(arguments, operationID, OperatorOptions[HostReboot]{
 						BaseOperatorOptions: options,
 					})
@@ -132,49 +132,49 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 			},
 
 			SapInstanceStartOperatorName: map[string]OperatorBuilder{
-				"v1": func(operationID string, arguments OperatorArguments) Operator {
+				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewSAPInstanceStart(arguments, operationID, OperatorOptions[SAPInstanceStart]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
 			SapInstanceStopOperatorName: map[string]OperatorBuilder{
-				"v1": func(operationID string, arguments OperatorArguments) Operator {
+				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewSAPInstanceStop(arguments, operationID, OperatorOptions[SAPInstanceStop]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
 			SapSystemStartOperatorName: map[string]OperatorBuilder{
-				"v1": func(operationID string, arguments OperatorArguments) Operator {
+				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewSAPSystemStart(arguments, operationID, OperatorOptions[SAPSystemStart]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
 			SapSystemStopOperatorName: map[string]OperatorBuilder{
-				"v1": func(operationID string, arguments OperatorArguments) Operator {
+				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewSAPSystemStop(arguments, operationID, OperatorOptions[SAPSystemStop]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
 			SaptuneApplySolutionOperatorName: map[string]OperatorBuilder{
-				"v1": func(operationID string, arguments OperatorArguments) Operator {
+				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewSaptuneApplySolution(arguments, operationID, OperatorOptions[SaptuneApplySolution]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
 			SaptuneChangeSolutionOperatorName: map[string]OperatorBuilder{
-				"v1": func(operationID string, arguments OperatorArguments) Operator {
+				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewSaptuneChangeSolution(arguments, operationID, OperatorOptions[SaptuneChangeSolution]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
 			PacemakerEnableOperatorName: map[string]OperatorBuilder{
-				"v1": func(operationID string, arguments OperatorArguments) Operator {
+				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewServiceEnable(PacemakerEnableOperatorName, arguments, operationID, OperatorOptions[ServiceEnable]{
 						BaseOperatorOptions: options,
 						OperatorOptions: []Option[ServiceEnable]{
@@ -184,7 +184,7 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 				},
 			},
 			PacemakerDisableOperatorName: map[string]OperatorBuilder{
-				"v1": func(operationID string, arguments OperatorArguments) Operator {
+				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewServiceDisable(PacemakerDisableOperatorName, arguments, operationID, OperatorOptions[ServiceDisable]{
 						BaseOperatorOptions: options,
 						OperatorOptions: []Option[ServiceDisable]{

--- a/pkg/operator/registry.go
+++ b/pkg/operator/registry.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 )
 
-type OperatorNotFoundError struct {
+type NotFoundError struct {
 	Name string
 }
 
-func (e *OperatorNotFoundError) Error() string {
+func (e *NotFoundError) Error() string {
 	return fmt.Sprintf("operator %s not found", e.Name)
 }
 
@@ -60,7 +60,7 @@ func (m *Registry) GetOperatorBuilder(name string) (OperatorBuilder, error) {
 	if g, found := m.operators[operatorName][version]; found {
 		return g, nil
 	}
-	return nil, &OperatorNotFoundError{Name: name}
+	return nil, &NotFoundError{Name: name}
 }
 
 func (m *Registry) AvailableOperators() []string {
@@ -84,7 +84,7 @@ func (m *Registry) AvailableOperators() []string {
 func (m *Registry) getLatestVersionForOperator(name string) (string, error) {
 	availableOperators, found := m.operators[name]
 	if !found {
-		return "", &OperatorNotFoundError{Name: name}
+		return "", &NotFoundError{Name: name}
 	}
 	versions := []string{}
 	for v := range availableOperators {

--- a/pkg/operator/registry.go
+++ b/pkg/operator/registry.go
@@ -14,10 +14,10 @@ func (e *NotFoundError) Error() string {
 	return fmt.Sprintf("operator %s not found", e.Name)
 }
 
-type OperatorBuilder func(operationID string, arguments Arguments) Operator
+type Builder func(operationID string, arguments Arguments) Operator
 
 // map[operatorName]map[operatorVersion]OperatorBuilder
-type OperatorBuildersTree map[string]map[string]OperatorBuilder
+type OperatorBuildersTree map[string]map[string]Builder
 
 func extractOperatorNameAndVersion(operatorName string) (string, string, error) {
 	parts := strings.Split(operatorName, "@")
@@ -44,7 +44,7 @@ func NewRegistry(operators OperatorBuildersTree) *Registry {
 	}
 }
 
-func (m *Registry) GetOperatorBuilder(name string) (OperatorBuilder, error) {
+func (m *Registry) GetOperatorBuilder(name string) (Builder, error) {
 	operatorName, version, err := extractOperatorNameAndVersion(name)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func (m *Registry) getLatestVersionForOperator(name string) (string, error) {
 func StandardRegistry(options ...BaseOperatorOption) *Registry {
 	return &Registry{
 		operators: OperatorBuildersTree{
-			ClusterMaintenanceChangeOperatorName: map[string]OperatorBuilder{
+			ClusterMaintenanceChangeOperatorName: map[string]Builder{
 				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewClusterMaintenanceChange(arguments, operationID, Options[ClusterMaintenanceChange]{
 						BaseOperatorOptions: options,
@@ -107,7 +107,7 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 				},
 			},
 
-			CrmClusterStartOperatorName: map[string]OperatorBuilder{
+			CrmClusterStartOperatorName: map[string]Builder{
 				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewCrmClusterStart(arguments, operationID, Options[CrmClusterStart]{
 						BaseOperatorOptions: options,
@@ -115,7 +115,7 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 				},
 			},
 
-			CrmClusterStopOperatorName: map[string]OperatorBuilder{
+			CrmClusterStopOperatorName: map[string]Builder{
 				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewCrmClusterStop(arguments, operationID, Options[CrmClusterStop]{
 						BaseOperatorOptions: options,
@@ -123,7 +123,7 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 				},
 			},
 
-			HostRebootOperatorName: map[string]OperatorBuilder{
+			HostRebootOperatorName: map[string]Builder{
 				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewHostReboot(arguments, operationID, Options[HostReboot]{
 						BaseOperatorOptions: options,
@@ -131,49 +131,49 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 				},
 			},
 
-			SapInstanceStartOperatorName: map[string]OperatorBuilder{
+			SapInstanceStartOperatorName: map[string]Builder{
 				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewSAPInstanceStart(arguments, operationID, Options[SAPInstanceStart]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
-			SapInstanceStopOperatorName: map[string]OperatorBuilder{
+			SapInstanceStopOperatorName: map[string]Builder{
 				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewSAPInstanceStop(arguments, operationID, Options[SAPInstanceStop]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
-			SapSystemStartOperatorName: map[string]OperatorBuilder{
+			SapSystemStartOperatorName: map[string]Builder{
 				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewSAPSystemStart(arguments, operationID, Options[SAPSystemStart]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
-			SapSystemStopOperatorName: map[string]OperatorBuilder{
+			SapSystemStopOperatorName: map[string]Builder{
 				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewSAPSystemStop(arguments, operationID, Options[SAPSystemStop]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
-			SaptuneApplySolutionOperatorName: map[string]OperatorBuilder{
+			SaptuneApplySolutionOperatorName: map[string]Builder{
 				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewSaptuneApplySolution(arguments, operationID, Options[SaptuneApplySolution]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
-			SaptuneChangeSolutionOperatorName: map[string]OperatorBuilder{
+			SaptuneChangeSolutionOperatorName: map[string]Builder{
 				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewSaptuneChangeSolution(arguments, operationID, Options[SaptuneChangeSolution]{
 						BaseOperatorOptions: options,
 					})
 				},
 			},
-			PacemakerEnableOperatorName: map[string]OperatorBuilder{
+			PacemakerEnableOperatorName: map[string]Builder{
 				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewServiceEnable(PacemakerEnableOperatorName, arguments, operationID, Options[ServiceEnable]{
 						BaseOperatorOptions: options,
@@ -183,7 +183,7 @@ func StandardRegistry(options ...BaseOperatorOption) *Registry {
 					})
 				},
 			},
-			PacemakerDisableOperatorName: map[string]OperatorBuilder{
+			PacemakerDisableOperatorName: map[string]Builder{
 				"v1": func(operationID string, arguments Arguments) Operator {
 					return NewServiceDisable(PacemakerDisableOperatorName, arguments, operationID, Options[ServiceDisable]{
 						BaseOperatorOptions: options,

--- a/pkg/operator/registry_test.go
+++ b/pkg/operator/registry_test.go
@@ -18,7 +18,7 @@ func TestRegistryTest(t *testing.T) {
 }
 
 func (suite *RegistryTest) TestRegistryAvailableOperators() {
-	registry := operator.NewRegistry(operator.OperatorBuildersTree{
+	registry := operator.NewRegistry(operator.BuildersTree{
 		operator.SaptuneApplySolutionOperatorName: map[string]operator.Builder{
 			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
@@ -48,7 +48,7 @@ func (suite *RegistryTest) TestRegistryAvailableOperators() {
 }
 
 func (suite *RegistryTest) TestGetOperatorBuilderNotFound() {
-	registry := operator.NewRegistry(operator.OperatorBuildersTree{
+	registry := operator.NewRegistry(operator.BuildersTree{
 		operator.SaptuneApplySolutionOperatorName: map[string]operator.Builder{
 			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
@@ -68,7 +68,7 @@ func (suite *RegistryTest) TestGetOperatorBuilderNotFound() {
 
 func (suite *RegistryTest) TestGetOperatorBuilderFoundWithVersion() {
 	foundOperator := mocks.NewMockOperator(suite.T())
-	registry := operator.NewRegistry(operator.OperatorBuildersTree{
+	registry := operator.NewRegistry(operator.BuildersTree{
 		operator.SaptuneApplySolutionOperatorName: map[string]operator.Builder{
 			"v1": func(_ string, _ operator.Arguments) operator.Operator { return foundOperator },
 			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
@@ -90,7 +90,7 @@ func (suite *RegistryTest) TestGetOperatorBuilderFoundWithVersion() {
 
 func (suite *RegistryTest) TestGetOperatorBuilderFoundWithoutVersionGetLast() {
 	foundOperator := mocks.NewMockOperator(suite.T())
-	registry := operator.NewRegistry(operator.OperatorBuildersTree{
+	registry := operator.NewRegistry(operator.BuildersTree{
 		operator.SaptuneApplySolutionOperatorName: map[string]operator.Builder{
 			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 			"v2": func(_ string, _ operator.Arguments) operator.Operator { return foundOperator },

--- a/pkg/operator/registry_test.go
+++ b/pkg/operator/registry_test.go
@@ -19,15 +19,15 @@ func TestRegistryTest(t *testing.T) {
 
 func (suite *RegistryTest) TestRegistryAvailableOperators() {
 	registry := operator.NewRegistry(operator.OperatorBuildersTree{
-		operator.SaptuneApplySolutionOperatorName: map[string]operator.OperatorBuilder{
+		operator.SaptuneApplySolutionOperatorName: map[string]operator.Builder{
 			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
-		"test": map[string]operator.OperatorBuilder{
+		"test": map[string]operator.Builder{
 			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
-		"test2": map[string]operator.OperatorBuilder{
+		"test2": map[string]operator.Builder{
 			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
 	})
@@ -49,15 +49,15 @@ func (suite *RegistryTest) TestRegistryAvailableOperators() {
 
 func (suite *RegistryTest) TestGetOperatorBuilderNotFound() {
 	registry := operator.NewRegistry(operator.OperatorBuildersTree{
-		operator.SaptuneApplySolutionOperatorName: map[string]operator.OperatorBuilder{
+		operator.SaptuneApplySolutionOperatorName: map[string]operator.Builder{
 			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
-		"test": map[string]operator.OperatorBuilder{
+		"test": map[string]operator.Builder{
 			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
-		"test2": map[string]operator.OperatorBuilder{
+		"test2": map[string]operator.Builder{
 			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
 	})
@@ -69,15 +69,15 @@ func (suite *RegistryTest) TestGetOperatorBuilderNotFound() {
 func (suite *RegistryTest) TestGetOperatorBuilderFoundWithVersion() {
 	foundOperator := mocks.NewMockOperator(suite.T())
 	registry := operator.NewRegistry(operator.OperatorBuildersTree{
-		operator.SaptuneApplySolutionOperatorName: map[string]operator.OperatorBuilder{
+		operator.SaptuneApplySolutionOperatorName: map[string]operator.Builder{
 			"v1": func(_ string, _ operator.Arguments) operator.Operator { return foundOperator },
 			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
-		"test": map[string]operator.OperatorBuilder{
+		"test": map[string]operator.Builder{
 			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
-		"test2": map[string]operator.OperatorBuilder{
+		"test2": map[string]operator.Builder{
 			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
 	})
@@ -91,15 +91,15 @@ func (suite *RegistryTest) TestGetOperatorBuilderFoundWithVersion() {
 func (suite *RegistryTest) TestGetOperatorBuilderFoundWithoutVersionGetLast() {
 	foundOperator := mocks.NewMockOperator(suite.T())
 	registry := operator.NewRegistry(operator.OperatorBuildersTree{
-		operator.SaptuneApplySolutionOperatorName: map[string]operator.OperatorBuilder{
+		operator.SaptuneApplySolutionOperatorName: map[string]operator.Builder{
 			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 			"v2": func(_ string, _ operator.Arguments) operator.Operator { return foundOperator },
 		},
-		"test": map[string]operator.OperatorBuilder{
+		"test": map[string]operator.Builder{
 			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
-		"test2": map[string]operator.OperatorBuilder{
+		"test2": map[string]operator.Builder{
 			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
 	})

--- a/pkg/operator/registry_test.go
+++ b/pkg/operator/registry_test.go
@@ -20,15 +20,15 @@ func TestRegistryTest(t *testing.T) {
 func (suite *RegistryTest) TestRegistryAvailableOperators() {
 	registry := operator.NewRegistry(operator.OperatorBuildersTree{
 		operator.SaptuneApplySolutionOperatorName: map[string]operator.OperatorBuilder{
-			"v1": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
-			"v2": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v2": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
 		},
 		"test": map[string]operator.OperatorBuilder{
-			"v1": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
-			"v2": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v2": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
 		},
 		"test2": map[string]operator.OperatorBuilder{
-			"v1": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
 		},
 	})
 
@@ -50,15 +50,15 @@ func (suite *RegistryTest) TestRegistryAvailableOperators() {
 func (suite *RegistryTest) TestGetOperatorBuilderNotFound() {
 	registry := operator.NewRegistry(operator.OperatorBuildersTree{
 		operator.SaptuneApplySolutionOperatorName: map[string]operator.OperatorBuilder{
-			"v1": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
-			"v2": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v2": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
 		},
 		"test": map[string]operator.OperatorBuilder{
-			"v1": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
-			"v2": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v2": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
 		},
 		"test2": map[string]operator.OperatorBuilder{
-			"v1": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
 		},
 	})
 	_, err := registry.GetOperatorBuilder("other@v1")
@@ -70,15 +70,15 @@ func (suite *RegistryTest) TestGetOperatorBuilderFoundWithVersion() {
 	foundOperator := mocks.NewMockOperator(suite.T())
 	registry := operator.NewRegistry(operator.OperatorBuildersTree{
 		operator.SaptuneApplySolutionOperatorName: map[string]operator.OperatorBuilder{
-			"v1": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return foundOperator },
-			"v2": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return foundOperator },
+			"v2": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
 		},
 		"test": map[string]operator.OperatorBuilder{
-			"v1": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
-			"v2": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v2": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
 		},
 		"test2": map[string]operator.OperatorBuilder{
-			"v1": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
 		},
 	})
 
@@ -92,15 +92,15 @@ func (suite *RegistryTest) TestGetOperatorBuilderFoundWithoutVersionGetLast() {
 	foundOperator := mocks.NewMockOperator(suite.T())
 	registry := operator.NewRegistry(operator.OperatorBuildersTree{
 		operator.SaptuneApplySolutionOperatorName: map[string]operator.OperatorBuilder{
-			"v1": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
-			"v2": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return foundOperator },
+			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v2": func(_ string, _ operator.OperatorArguments) operator.Operator { return foundOperator },
 		},
 		"test": map[string]operator.OperatorBuilder{
-			"v1": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
-			"v2": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v2": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
 		},
 		"test2": map[string]operator.OperatorBuilder{
-			"v1": func(operationID string, arguments operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
 		},
 	})
 

--- a/pkg/operator/registry_test.go
+++ b/pkg/operator/registry_test.go
@@ -20,15 +20,15 @@ func TestRegistryTest(t *testing.T) {
 func (suite *RegistryTest) TestRegistryAvailableOperators() {
 	registry := operator.NewRegistry(operator.OperatorBuildersTree{
 		operator.SaptuneApplySolutionOperatorName: map[string]operator.OperatorBuilder{
-			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
-			"v2": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
+			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
 		"test": map[string]operator.OperatorBuilder{
-			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
-			"v2": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
+			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
 		"test2": map[string]operator.OperatorBuilder{
-			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
 	})
 
@@ -50,15 +50,15 @@ func (suite *RegistryTest) TestRegistryAvailableOperators() {
 func (suite *RegistryTest) TestGetOperatorBuilderNotFound() {
 	registry := operator.NewRegistry(operator.OperatorBuildersTree{
 		operator.SaptuneApplySolutionOperatorName: map[string]operator.OperatorBuilder{
-			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
-			"v2": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
+			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
 		"test": map[string]operator.OperatorBuilder{
-			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
-			"v2": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
+			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
 		"test2": map[string]operator.OperatorBuilder{
-			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
 	})
 	_, err := registry.GetOperatorBuilder("other@v1")
@@ -70,15 +70,15 @@ func (suite *RegistryTest) TestGetOperatorBuilderFoundWithVersion() {
 	foundOperator := mocks.NewMockOperator(suite.T())
 	registry := operator.NewRegistry(operator.OperatorBuildersTree{
 		operator.SaptuneApplySolutionOperatorName: map[string]operator.OperatorBuilder{
-			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return foundOperator },
-			"v2": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.Arguments) operator.Operator { return foundOperator },
+			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
 		"test": map[string]operator.OperatorBuilder{
-			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
-			"v2": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
+			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
 		"test2": map[string]operator.OperatorBuilder{
-			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
 	})
 
@@ -92,15 +92,15 @@ func (suite *RegistryTest) TestGetOperatorBuilderFoundWithoutVersionGetLast() {
 	foundOperator := mocks.NewMockOperator(suite.T())
 	registry := operator.NewRegistry(operator.OperatorBuildersTree{
 		operator.SaptuneApplySolutionOperatorName: map[string]operator.OperatorBuilder{
-			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
-			"v2": func(_ string, _ operator.OperatorArguments) operator.Operator { return foundOperator },
+			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
+			"v2": func(_ string, _ operator.Arguments) operator.Operator { return foundOperator },
 		},
 		"test": map[string]operator.OperatorBuilder{
-			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
-			"v2": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
+			"v2": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
 		"test2": map[string]operator.OperatorBuilder{
-			"v1": func(_ string, _ operator.OperatorArguments) operator.Operator { return nil },
+			"v1": func(_ string, _ operator.Arguments) operator.Operator { return nil },
 		},
 	})
 

--- a/pkg/operator/sapinstancestart_v1.go
+++ b/pkg/operator/sapinstancestart_v1.go
@@ -166,7 +166,7 @@ func (s *SAPInstanceStart) rollback(ctx context.Context) error {
 	return nil
 }
 
-func (s *SAPInstanceStart) operationDiff(ctx context.Context) map[string]any {
+func (s *SAPInstanceStart) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
 	beforeDiffOutput := sapInstanceStartDiffOutput{

--- a/pkg/operator/sapinstancestart_v1.go
+++ b/pkg/operator/sapinstancestart_v1.go
@@ -184,13 +184,19 @@ func (s *SAPInstanceStart) operationDiff(_ context.Context) map[string]any {
 	beforeDiffOutput := sapInstanceStartDiffOutput{
 		Started: beforeStarted,
 	}
-	before, _ := json.Marshal(beforeDiffOutput)
+	before, err := json.Marshal(beforeDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling before diff output: %v", err))
+	}
 	diff["before"] = string(before)
 
 	afterDiffOutput := sapInstanceStartDiffOutput{
 		Started: afterStarted,
 	}
-	after, _ := json.Marshal(afterDiffOutput)
+	after, err := json.Marshal(afterDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling after diff output: %v", err))
+	}
 	diff["after"] = string(after)
 
 	return diff

--- a/pkg/operator/sapinstancestart_v1.go
+++ b/pkg/operator/sapinstancestart_v1.go
@@ -67,7 +67,7 @@ func WithCustomStartInterval(interval time.Duration) SAPInstanceStartOption {
 }
 
 func NewSAPInstanceStart(
-	arguments OperatorArguments,
+	arguments Arguments,
 	operationID string,
 	options OperatorOptions[SAPInstanceStart],
 ) *Executor {
@@ -253,7 +253,7 @@ func sleepContext(ctx context.Context, interval time.Duration) error {
 	}
 }
 
-func parseSAPStateChangeArguments(rawArguments OperatorArguments) (*sapStateChangeArguments, error) {
+func parseSAPStateChangeArguments(rawArguments Arguments) (*sapStateChangeArguments, error) {
 	instNumberArgument, found := rawArguments["instance_number"]
 	if !found {
 		return nil, fmt.Errorf("argument instance_number not provided, could not use the operator")

--- a/pkg/operator/sapinstancestart_v1.go
+++ b/pkg/operator/sapinstancestart_v1.go
@@ -166,6 +166,9 @@ func (s *SAPInstanceStart) rollback(ctx context.Context) error {
 	return nil
 }
 
+//	operationDiff needs to be refactored, ignoring duplication issues for now
+//
+// nolint: dupl
 func (s *SAPInstanceStart) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/pkg/operator/sapinstancestart_v1.go
+++ b/pkg/operator/sapinstancestart_v1.go
@@ -169,14 +169,26 @@ func (s *SAPInstanceStart) rollback(ctx context.Context) error {
 func (s *SAPInstanceStart) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
+	beforeStarted, ok := s.resources[beforeDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid beforeStarted value: cannot parse '%s' to bool",
+			s.resources[beforeDiffField]))
+	}
+
+	afterStarted, ok := s.resources[afterDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid afterStarted value: cannot parse '%s' to bool",
+			s.resources[afterDiffField]))
+	}
+
 	beforeDiffOutput := sapInstanceStartDiffOutput{
-		Started: s.resources[beforeDiffField].(bool),
+		Started: beforeStarted,
 	}
 	before, _ := json.Marshal(beforeDiffOutput)
 	diff["before"] = string(before)
 
 	afterDiffOutput := sapInstanceStartDiffOutput{
-		Started: s.resources[afterDiffField].(bool),
+		Started: afterStarted,
 	}
 	after, _ := json.Marshal(afterDiffOutput)
 	diff["after"] = string(after)

--- a/pkg/operator/sapinstancestart_v1.go
+++ b/pkg/operator/sapinstancestart_v1.go
@@ -69,7 +69,7 @@ func WithCustomStartInterval(interval time.Duration) SAPInstanceStartOption {
 func NewSAPInstanceStart(
 	arguments Arguments,
 	operationID string,
-	options OperatorOptions[SAPInstanceStart],
+	options Options[SAPInstanceStart],
 ) *Executor {
 	sapInstanceStart := &SAPInstanceStart{
 		baseOperator: newBaseOperator(

--- a/pkg/operator/sapinstancestart_v1_test.go
+++ b/pkg/operator/sapinstancestart_v1_test.go
@@ -30,7 +30,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartInstanceNumb
 	ctx := context.Background()
 
 	sapInstanceStartOperator := operator.NewSAPInstanceStart(
-		operator.OperatorArguments{},
+		operator.Arguments{},
 		"test-op",
 		operator.OperatorOptions[operator.SAPInstanceStart]{},
 	)
@@ -46,7 +46,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartInstanceNumb
 	ctx := context.Background()
 
 	sapInstanceStartOperator := operator.NewSAPInstanceStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": 0,
 		},
 		"test-op",
@@ -64,7 +64,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartTimeoutInval
 	ctx := context.Background()
 
 	sapInstanceStartOperator := operator.NewSAPInstanceStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"timeout":         "value",
 		},
@@ -88,7 +88,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartPlanError() 
 		Once()
 
 	sapInstanceStartOperator := operator.NewSAPInstanceStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"timeout":         300.0,
 		},
@@ -127,7 +127,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartCommitAlread
 		Once()
 
 	sapInstanceStartOperator := operator.NewSAPInstanceStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 		},
 		"test-op",
@@ -189,7 +189,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartCommitStarti
 		NotBefore(planGetProcesses)
 
 	sapInstanceStartOperator := operator.NewSAPInstanceStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 		},
 		"test-op",
@@ -251,7 +251,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartVerifyError(
 		NotBefore(verifyGetProcesses)
 
 	sapInstanceStartOperator := operator.NewSAPInstanceStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 		},
 		"test-op",
@@ -292,7 +292,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartVerifyTimeou
 		Return(nil, nil)
 
 	sapInstanceStartOperator := operator.NewSAPInstanceStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"timeout":         0.0,
 		},
@@ -338,7 +338,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartRollbackStop
 		Return(nil, errors.New("error stopping"))
 
 	sapInstanceStartOperator := operator.NewSAPInstanceStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 		},
 		"test-op",
@@ -389,7 +389,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartSuccess() {
 		NotBefore(planGetProcesses)
 
 	sapInstanceStartOperator := operator.NewSAPInstanceStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 		},
 		"test-op",
@@ -468,7 +468,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartSuccessMulti
 		Once()
 
 	sapInstanceStartOperator := operator.NewSAPInstanceStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"timeout":         5.0,
 		},

--- a/pkg/operator/sapinstancestart_v1_test.go
+++ b/pkg/operator/sapinstancestart_v1_test.go
@@ -32,7 +32,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartInstanceNumb
 	sapInstanceStartOperator := operator.NewSAPInstanceStart(
 		operator.Arguments{},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStart]{},
+		operator.Options[operator.SAPInstanceStart]{},
 	)
 
 	report := sapInstanceStartOperator.Run(ctx)
@@ -50,7 +50,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartInstanceNumb
 			"instance_number": 0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStart]{},
+		operator.Options[operator.SAPInstanceStart]{},
 	)
 
 	report := sapInstanceStartOperator.Run(ctx)
@@ -69,7 +69,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartTimeoutInval
 			"timeout":         "value",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStart]{},
+		operator.Options[operator.SAPInstanceStart]{},
 	)
 
 	report := sapInstanceStartOperator.Run(ctx)
@@ -93,7 +93,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartPlanError() 
 			"timeout":         300.0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStart]{
+		operator.Options[operator.SAPInstanceStart]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
 			},
@@ -131,7 +131,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartCommitAlread
 			"instance_number": "00",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStart]{
+		operator.Options[operator.SAPInstanceStart]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
 			},
@@ -193,7 +193,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartCommitStarti
 			"instance_number": "00",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStart]{
+		operator.Options[operator.SAPInstanceStart]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
 			},
@@ -255,7 +255,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartVerifyError(
 			"instance_number": "00",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStart]{
+		operator.Options[operator.SAPInstanceStart]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
 			},
@@ -297,7 +297,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartVerifyTimeou
 			"timeout":         0.0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStart]{
+		operator.Options[operator.SAPInstanceStart]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartInterval(0 * time.Second)),
@@ -342,7 +342,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartRollbackStop
 			"instance_number": "00",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStart]{
+		operator.Options[operator.SAPInstanceStart]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
 			},
@@ -393,7 +393,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartSuccess() {
 			"instance_number": "00",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStart]{
+		operator.Options[operator.SAPInstanceStart]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
 			},
@@ -473,7 +473,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStartSuccessMulti
 			"timeout":         5.0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStart]{
+		operator.Options[operator.SAPInstanceStart]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStart]{
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartSapcontrol(suite.mockSapcontrol)),
 				operator.Option[operator.SAPInstanceStart](operator.WithCustomStartInterval(0 * time.Second)),

--- a/pkg/operator/sapinstancestop_v1.go
+++ b/pkg/operator/sapinstancestop_v1.go
@@ -159,6 +159,9 @@ func (s *SAPInstanceStop) rollback(ctx context.Context) error {
 	return nil
 }
 
+//	operationDiff needs to be refactored, ignoring duplication issues for now
+//
+// nolint: dupl
 func (s *SAPInstanceStop) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/pkg/operator/sapinstancestop_v1.go
+++ b/pkg/operator/sapinstancestop_v1.go
@@ -162,14 +162,26 @@ func (s *SAPInstanceStop) rollback(ctx context.Context) error {
 func (s *SAPInstanceStop) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
+	beforeStopped, ok := s.resources[beforeDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid beforeStopped value: cannot parse '%s' to bool",
+			s.resources[beforeDiffField]))
+	}
+
+	afterStopped, ok := s.resources[afterDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid afterStopped value: cannot parse '%s' to bool",
+			s.resources[afterDiffField]))
+	}
+
 	beforeDiffOutput := sapInstanceStopDiffOutput{
-		Stopped: s.resources[beforeDiffField].(bool),
+		Stopped: beforeStopped,
 	}
 	before, _ := json.Marshal(beforeDiffOutput)
 	diff["before"] = string(before)
 
 	afterDiffOutput := sapInstanceStopDiffOutput{
-		Stopped: s.resources[afterDiffField].(bool),
+		Stopped: afterStopped,
 	}
 	after, _ := json.Marshal(afterDiffOutput)
 	diff["after"] = string(after)

--- a/pkg/operator/sapinstancestop_v1.go
+++ b/pkg/operator/sapinstancestop_v1.go
@@ -62,7 +62,7 @@ func WithCustomStopInterval(interval time.Duration) SAPInstanceStopOption {
 func NewSAPInstanceStop(
 	arguments Arguments,
 	operationID string,
-	options OperatorOptions[SAPInstanceStop],
+	options Options[SAPInstanceStop],
 ) *Executor {
 	sapInstanceStop := &SAPInstanceStop{
 		baseOperator: newBaseOperator(

--- a/pkg/operator/sapinstancestop_v1.go
+++ b/pkg/operator/sapinstancestop_v1.go
@@ -159,7 +159,7 @@ func (s *SAPInstanceStop) rollback(ctx context.Context) error {
 	return nil
 }
 
-func (s *SAPInstanceStop) operationDiff(ctx context.Context) map[string]any {
+func (s *SAPInstanceStop) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
 	beforeDiffOutput := sapInstanceStopDiffOutput{

--- a/pkg/operator/sapinstancestop_v1.go
+++ b/pkg/operator/sapinstancestop_v1.go
@@ -60,7 +60,7 @@ func WithCustomStopInterval(interval time.Duration) SAPInstanceStopOption {
 //   If an error occurs during the COMMIT or VERIFY phase, the instance is started back again.
 
 func NewSAPInstanceStop(
-	arguments OperatorArguments,
+	arguments Arguments,
 	operationID string,
 	options OperatorOptions[SAPInstanceStop],
 ) *Executor {

--- a/pkg/operator/sapinstancestop_v1.go
+++ b/pkg/operator/sapinstancestop_v1.go
@@ -177,13 +177,19 @@ func (s *SAPInstanceStop) operationDiff(_ context.Context) map[string]any {
 	beforeDiffOutput := sapInstanceStopDiffOutput{
 		Stopped: beforeStopped,
 	}
-	before, _ := json.Marshal(beforeDiffOutput)
+	before, err := json.Marshal(beforeDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling before diff output: %v", err))
+	}
 	diff["before"] = string(before)
 
 	afterDiffOutput := sapInstanceStopDiffOutput{
 		Stopped: afterStopped,
 	}
-	after, _ := json.Marshal(afterDiffOutput)
+	after, err := json.Marshal(afterDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling after diff output: %v", err))
+	}
 	diff["after"] = string(after)
 
 	return diff

--- a/pkg/operator/sapinstancestop_v1_test.go
+++ b/pkg/operator/sapinstancestop_v1_test.go
@@ -30,7 +30,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopInstanceNumber
 	ctx := context.Background()
 
 	sapInstanceStopOperator := operator.NewSAPInstanceStop(
-		operator.OperatorArguments{},
+		operator.Arguments{},
 		"test-op",
 		operator.OperatorOptions[operator.SAPInstanceStop]{},
 	)
@@ -46,7 +46,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopInstanceNumber
 	ctx := context.Background()
 
 	sapInstanceStopOperator := operator.NewSAPInstanceStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": 0,
 		},
 		"test-op",
@@ -64,7 +64,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopTimeoutInvalid
 	ctx := context.Background()
 
 	sapInstanceStopOperator := operator.NewSAPInstanceStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"timeout":         "value",
 		},
@@ -88,7 +88,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopPlanError() {
 		Once()
 
 	sapInstanceStopOperator := operator.NewSAPInstanceStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"timeout":         300.0,
 		},
@@ -127,7 +127,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopCommitAlreadyS
 		Once()
 
 	sapInstanceStopOperator := operator.NewSAPInstanceStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 		},
 		"test-op",
@@ -189,7 +189,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopCommitStopping
 		Once()
 
 	sapInstanceStopOperator := operator.NewSAPInstanceStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 		},
 		"test-op",
@@ -252,7 +252,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopVerifyError() 
 		NotBefore(verifyGetProcess)
 
 	sapInstanceStopOperator := operator.NewSAPInstanceStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 		},
 		"test-op",
@@ -293,7 +293,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopVerifyTimeout(
 		Return(nil, nil)
 
 	sapInstanceStopOperator := operator.NewSAPInstanceStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"timeout":         0.0,
 		},
@@ -339,7 +339,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopRollbackStarti
 		Return(nil, errors.New("error starting"))
 
 	sapInstanceStopOperator := operator.NewSAPInstanceStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 		},
 		"test-op",
@@ -390,7 +390,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopSuccess() {
 		NotBefore(planGetProcesses)
 
 	sapInstanceStopOperator := operator.NewSAPInstanceStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 		},
 		"test-op",
@@ -463,7 +463,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStopSuccessMultip
 		Once()
 
 	sapInstanceStartOperator := operator.NewSAPInstanceStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"timeout":         5.0,
 		},

--- a/pkg/operator/sapinstancestop_v1_test.go
+++ b/pkg/operator/sapinstancestop_v1_test.go
@@ -32,7 +32,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopInstanceNumber
 	sapInstanceStopOperator := operator.NewSAPInstanceStop(
 		operator.Arguments{},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStop]{},
+		operator.Options[operator.SAPInstanceStop]{},
 	)
 
 	report := sapInstanceStopOperator.Run(ctx)
@@ -50,7 +50,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopInstanceNumber
 			"instance_number": 0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStop]{},
+		operator.Options[operator.SAPInstanceStop]{},
 	)
 
 	report := sapInstanceStopOperator.Run(ctx)
@@ -69,7 +69,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopTimeoutInvalid
 			"timeout":         "value",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStop]{},
+		operator.Options[operator.SAPInstanceStop]{},
 	)
 
 	report := sapInstanceStopOperator.Run(ctx)
@@ -93,7 +93,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopPlanError() {
 			"timeout":         300.0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStop]{
+		operator.Options[operator.SAPInstanceStop]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStop]{
 				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopSapcontrol(suite.mockSapcontrol)),
 			},
@@ -131,7 +131,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopCommitAlreadyS
 			"instance_number": "00",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStop]{
+		operator.Options[operator.SAPInstanceStop]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStop]{
 				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopSapcontrol(suite.mockSapcontrol)),
 			},
@@ -193,7 +193,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopCommitStopping
 			"instance_number": "00",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStop]{
+		operator.Options[operator.SAPInstanceStop]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStop]{
 				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopSapcontrol(suite.mockSapcontrol)),
 			},
@@ -256,7 +256,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopVerifyError() 
 			"instance_number": "00",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStop]{
+		operator.Options[operator.SAPInstanceStop]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStop]{
 				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopSapcontrol(suite.mockSapcontrol)),
 			},
@@ -298,7 +298,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopVerifyTimeout(
 			"timeout":         0.0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStop]{
+		operator.Options[operator.SAPInstanceStop]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStop]{
 				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopSapcontrol(suite.mockSapcontrol)),
 				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopInterval(0 * time.Second)),
@@ -343,7 +343,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopRollbackStarti
 			"instance_number": "00",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStop]{
+		operator.Options[operator.SAPInstanceStop]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStop]{
 				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopSapcontrol(suite.mockSapcontrol)),
 			},
@@ -394,7 +394,7 @@ func (suite *SAPInstanceStopOperatorTestSuite) TestSAPInstanceStopSuccess() {
 			"instance_number": "00",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStop]{
+		operator.Options[operator.SAPInstanceStop]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStop]{
 				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopSapcontrol(suite.mockSapcontrol)),
 			},
@@ -468,7 +468,7 @@ func (suite *SAPInstanceStartOperatorTestSuite) TestSAPInstanceStopSuccessMultip
 			"timeout":         5.0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPInstanceStop]{
+		operator.Options[operator.SAPInstanceStop]{
 			OperatorOptions: []operator.Option[operator.SAPInstanceStop]{
 				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopSapcontrol(suite.mockSapcontrol)),
 				operator.Option[operator.SAPInstanceStop](operator.WithCustomStopInterval(0 * time.Second)),

--- a/pkg/operator/sapsystemstart_v1.go
+++ b/pkg/operator/sapsystemstart_v1.go
@@ -189,14 +189,26 @@ func (s *SAPSystemStart) rollback(ctx context.Context) error {
 func (s *SAPSystemStart) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
+	beforeStarted, ok := s.resources[beforeDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid beforeStarted value: cannot parse '%s' to bool",
+			s.resources[beforeDiffField]))
+	}
+
+	afterStarted, ok := s.resources[afterDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid afterStarted value: cannot parse '%s' to bool",
+			s.resources[afterDiffField]))
+	}
+
 	beforeDiffOutput := sapSystemStartDiffOutput{
-		Started: s.resources[beforeDiffField].(bool),
+		Started: beforeStarted,
 	}
 	before, _ := json.Marshal(beforeDiffOutput)
 	diff["before"] = string(before)
 
 	afterDiffOutput := sapSystemStartDiffOutput{
-		Started: s.resources[afterDiffField].(bool),
+		Started: afterStarted,
 	}
 	after, _ := json.Marshal(afterDiffOutput)
 	diff["after"] = string(after)

--- a/pkg/operator/sapsystemstart_v1.go
+++ b/pkg/operator/sapsystemstart_v1.go
@@ -204,13 +204,19 @@ func (s *SAPSystemStart) operationDiff(_ context.Context) map[string]any {
 	beforeDiffOutput := sapSystemStartDiffOutput{
 		Started: beforeStarted,
 	}
-	before, _ := json.Marshal(beforeDiffOutput)
+	before, err := json.Marshal(beforeDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling before diff output: %v", err))
+	}
 	diff["before"] = string(before)
 
 	afterDiffOutput := sapSystemStartDiffOutput{
 		Started: afterStarted,
 	}
-	after, _ := json.Marshal(afterDiffOutput)
+	after, err := json.Marshal(afterDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling after diff output: %v", err))
+	}
 	diff["after"] = string(after)
 
 	return diff

--- a/pkg/operator/sapsystemstart_v1.go
+++ b/pkg/operator/sapsystemstart_v1.go
@@ -186,6 +186,9 @@ func (s *SAPSystemStart) rollback(ctx context.Context) error {
 	return nil
 }
 
+//	operationDiff needs to be refactored, ignoring duplication issues for now
+//
+// nolint: dupl
 func (s *SAPSystemStart) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/pkg/operator/sapsystemstart_v1.go
+++ b/pkg/operator/sapsystemstart_v1.go
@@ -77,7 +77,7 @@ func WithCustomStartSystemInterval(interval time.Duration) SAPSystemStartOption 
 }
 
 func NewSAPSystemStart(
-	arguments OperatorArguments,
+	arguments Arguments,
 	operationID string,
 	options OperatorOptions[SAPSystemStart],
 ) *Executor {
@@ -270,7 +270,7 @@ func waitUntilSapSystemState(
 
 }
 
-func parseSAPSystemStateChangeArguments(rawArguments OperatorArguments) (*sapSystemStateChangeArguments, error) {
+func parseSAPSystemStateChangeArguments(rawArguments Arguments) (*sapSystemStateChangeArguments, error) {
 	instNumberArgument, found := rawArguments["instance_number"]
 	if !found {
 		return nil, fmt.Errorf("argument instance_number not provided, could not use the operator")

--- a/pkg/operator/sapsystemstart_v1.go
+++ b/pkg/operator/sapsystemstart_v1.go
@@ -185,7 +185,7 @@ func (s *SAPSystemStart) rollback(ctx context.Context) error {
 	return nil
 }
 
-func (s *SAPSystemStart) operationDiff(ctx context.Context) map[string]any {
+func (s *SAPSystemStart) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
 	beforeDiffOutput := sapSystemStartDiffOutput{

--- a/pkg/operator/sapsystemstart_v1.go
+++ b/pkg/operator/sapsystemstart_v1.go
@@ -79,7 +79,7 @@ func WithCustomStartSystemInterval(interval time.Duration) SAPSystemStartOption 
 func NewSAPSystemStart(
 	arguments Arguments,
 	operationID string,
-	options OperatorOptions[SAPSystemStart],
+	options Options[SAPSystemStart],
 ) *Executor {
 	sapSystemStart := &SAPSystemStart{
 		baseOperator: newBaseOperator(

--- a/pkg/operator/sapsystemstart_v1.go
+++ b/pkg/operator/sapsystemstart_v1.go
@@ -40,7 +40,8 @@ type SAPSystemStartOption Option[SAPSystemStart]
 // Arguments:
 //  instance_number (required): String with the instance number of local instance to start the whole system
 //  timeout: Timeout in seconds to wait until the system is started
-//  instance_type: Instance type to filter in the StartSystem process. Values: all|abap|j2ee|scs|enqrep. Default value: all
+//  instance_type: Instance type to filter in the StartSystem process. Values: all|abap|j2ee|scs|enqrep.
+//  Default value: all
 //
 // # Execution Phases
 //

--- a/pkg/operator/sapsystemstart_v1_test.go
+++ b/pkg/operator/sapsystemstart_v1_test.go
@@ -32,7 +32,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartInstanceNumberMi
 	sapSystemStartOperator := operator.NewSAPSystemStart(
 		operator.Arguments{},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStart]{},
+		operator.Options[operator.SAPSystemStart]{},
 	)
 
 	report := sapSystemStartOperator.Run(ctx)
@@ -50,7 +50,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartInstanceNumberIn
 			"instance_number": 0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStart]{},
+		operator.Options[operator.SAPSystemStart]{},
 	)
 
 	report := sapSystemStartOperator.Run(ctx)
@@ -69,7 +69,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartTimeoutInvalid()
 			"timeout":         "value",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStart]{},
+		operator.Options[operator.SAPSystemStart]{},
 	)
 
 	report := sapSystemStartOperator.Run(ctx)
@@ -88,7 +88,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartInstanceTypeInva
 			"instance_type":   0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStart]{},
+		operator.Options[operator.SAPSystemStart]{},
 	)
 
 	report := sapSystemStartOperator.Run(ctx)
@@ -107,7 +107,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartInstanceTypeUnkn
 			"instance_type":   "unknown",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStart]{},
+		operator.Options[operator.SAPSystemStart]{},
 	)
 
 	report := sapSystemStartOperator.Run(ctx)
@@ -131,7 +131,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartPlanError() {
 			"timeout":         300.0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStart]{
+		operator.Options[operator.SAPSystemStart]{
 			OperatorOptions: []operator.Option[operator.SAPSystemStart]{
 				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
 			},
@@ -169,7 +169,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartCommitAlreadySta
 			"instance_number": "00",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStart]{
+		operator.Options[operator.SAPSystemStart]{
 			OperatorOptions: []operator.Option[operator.SAPSystemStart]{
 				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
 			},
@@ -240,7 +240,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartCommitAlreadySta
 				"instance_type":   tt.instanceType,
 			},
 			"test-op",
-			operator.OperatorOptions[operator.SAPSystemStart]{
+			operator.Options[operator.SAPSystemStart]{
 				OperatorOptions: []operator.Option[operator.SAPSystemStart]{
 					operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
 				},
@@ -307,7 +307,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartCommitStartingEr
 			"instance_number": "00",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStart]{
+		operator.Options[operator.SAPSystemStart]{
 			OperatorOptions: []operator.Option[operator.SAPSystemStart]{
 				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
 			},
@@ -374,7 +374,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartVerifyError() {
 			"instance_number": "00",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStart]{
+		operator.Options[operator.SAPSystemStart]{
 			OperatorOptions: []operator.Option[operator.SAPSystemStart]{
 				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
 			},
@@ -416,7 +416,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartVerifyTimeout() 
 			"timeout":         0.0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStart]{
+		operator.Options[operator.SAPSystemStart]{
 			OperatorOptions: []operator.Option[operator.SAPSystemStart]{
 				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
 				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemInterval(0 * time.Second)),
@@ -469,7 +469,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartRollbackStopping
 			"instance_type":   "abap",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStart]{
+		operator.Options[operator.SAPSystemStart]{
 			OperatorOptions: []operator.Option[operator.SAPSystemStart]{
 				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
 			},
@@ -563,7 +563,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartSuccess() {
 				"instance_type":   tt.instanceType,
 			},
 			"test-op",
-			operator.OperatorOptions[operator.SAPSystemStart]{
+			operator.Options[operator.SAPSystemStart]{
 				OperatorOptions: []operator.Option[operator.SAPSystemStart]{
 					operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
 				},
@@ -638,7 +638,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartSuccessMultipleQ
 			"timeout":         5.0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStart]{
+		operator.Options[operator.SAPSystemStart]{
 			OperatorOptions: []operator.Option[operator.SAPSystemStart]{
 				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemSapcontrol(suite.mockSapcontrol)),
 				operator.Option[operator.SAPSystemStart](operator.WithCustomStartSystemInterval(0 * time.Second)),

--- a/pkg/operator/sapsystemstart_v1_test.go
+++ b/pkg/operator/sapsystemstart_v1_test.go
@@ -30,7 +30,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartInstanceNumberMi
 	ctx := context.Background()
 
 	sapSystemStartOperator := operator.NewSAPSystemStart(
-		operator.OperatorArguments{},
+		operator.Arguments{},
 		"test-op",
 		operator.OperatorOptions[operator.SAPSystemStart]{},
 	)
@@ -46,7 +46,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartInstanceNumberIn
 	ctx := context.Background()
 
 	sapSystemStartOperator := operator.NewSAPSystemStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": 0,
 		},
 		"test-op",
@@ -64,7 +64,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartTimeoutInvalid()
 	ctx := context.Background()
 
 	sapSystemStartOperator := operator.NewSAPSystemStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"timeout":         "value",
 		},
@@ -83,7 +83,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartInstanceTypeInva
 	ctx := context.Background()
 
 	sapSystemStartOperator := operator.NewSAPSystemStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"instance_type":   0,
 		},
@@ -102,7 +102,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartInstanceTypeUnkn
 	ctx := context.Background()
 
 	sapSystemStartOperator := operator.NewSAPSystemStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"instance_type":   "unknown",
 		},
@@ -126,7 +126,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartPlanError() {
 		Once()
 
 	sapSystemStartOperator := operator.NewSAPSystemStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"timeout":         300.0,
 		},
@@ -165,7 +165,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartCommitAlreadySta
 		Once()
 
 	sapSystemStartOperator := operator.NewSAPSystemStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 		},
 		"test-op",
@@ -235,7 +235,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartCommitAlreadySta
 			Once()
 
 		sapSystemStartOperator := operator.NewSAPSystemStart(
-			operator.OperatorArguments{
+			operator.Arguments{
 				"instance_number": "00",
 				"instance_type":   tt.instanceType,
 			},
@@ -303,7 +303,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartCommitStartingEr
 		NotBefore(rollbackStopSystem)
 
 	sapSystemStartOperator := operator.NewSAPSystemStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 		},
 		"test-op",
@@ -370,7 +370,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartVerifyError() {
 		NotBefore(rollbackStopSystem)
 
 	sapSystemStartOperator := operator.NewSAPSystemStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 		},
 		"test-op",
@@ -411,7 +411,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartVerifyTimeout() 
 		Return(nil, nil)
 
 	sapSystemStartOperator := operator.NewSAPSystemStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"timeout":         0.0,
 		},
@@ -464,7 +464,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartRollbackStopping
 		Return(nil, errors.New("error stopping"))
 
 	sapSystemStartOperator := operator.NewSAPSystemStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"instance_type":   "abap",
 		},
@@ -558,7 +558,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartSuccess() {
 			NotBefore(planGetInstances)
 
 		sapSystemStartOperator := operator.NewSAPSystemStart(
-			operator.OperatorArguments{
+			operator.Arguments{
 				"instance_number": "00",
 				"instance_type":   tt.instanceType,
 			},
@@ -633,7 +633,7 @@ func (suite *SAPSystemStartOperatorTestSuite) TestSAPSystemStartSuccessMultipleQ
 		Once()
 
 	sapSystemStartOperator := operator.NewSAPSystemStart(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"timeout":         5.0,
 		},

--- a/pkg/operator/sapsystemstop_v1.go
+++ b/pkg/operator/sapsystemstop_v1.go
@@ -169,7 +169,7 @@ func (s *SAPSystemStop) rollback(ctx context.Context) error {
 	return nil
 }
 
-func (s *SAPSystemStop) operationDiff(ctx context.Context) map[string]any {
+func (s *SAPSystemStop) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
 	beforeDiffOutput := sapSystemStopDiffOutput{

--- a/pkg/operator/sapsystemstop_v1.go
+++ b/pkg/operator/sapsystemstop_v1.go
@@ -24,7 +24,8 @@ type SAPSystemStopOption Option[SAPSystemStop]
 // Arguments:
 //  instance_number (required): String with the instance number of local instance to stop the whole system
 //  timeout: Timeout in seconds to wait until the system is stopped
-//  instance_type: Instance type to filter in the StopSystem process. Values: all|abap|j2ee|scs|enqrep. Default value: all
+//  instance_type: Instance type to filter in the StopSystem process. Values: all|abap|j2ee|scs|enqrep.
+//  Default value: all
 //
 // # Execution Phases
 //

--- a/pkg/operator/sapsystemstop_v1.go
+++ b/pkg/operator/sapsystemstop_v1.go
@@ -61,7 +61,7 @@ func WithCustomStopSystemInterval(interval time.Duration) SAPSystemStopOption {
 }
 
 func NewSAPSystemStop(
-	arguments OperatorArguments,
+	arguments Arguments,
 	operationID string,
 	options OperatorOptions[SAPSystemStop],
 ) *Executor {

--- a/pkg/operator/sapsystemstop_v1.go
+++ b/pkg/operator/sapsystemstop_v1.go
@@ -170,6 +170,9 @@ func (s *SAPSystemStop) rollback(ctx context.Context) error {
 	return nil
 }
 
+//	operationDiff needs to be refactored, ignoring duplication issues for now
+//
+// nolint: dupl
 func (s *SAPSystemStop) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/pkg/operator/sapsystemstop_v1.go
+++ b/pkg/operator/sapsystemstop_v1.go
@@ -173,14 +173,26 @@ func (s *SAPSystemStop) rollback(ctx context.Context) error {
 func (s *SAPSystemStop) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
+	beforeStopped, ok := s.resources[beforeDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid beforeStopped value: cannot parse '%s' to bool",
+			s.resources[beforeDiffField]))
+	}
+
+	afterStopped, ok := s.resources[afterDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid afterStopped value: cannot parse '%s' to bool",
+			s.resources[afterDiffField]))
+	}
+
 	beforeDiffOutput := sapSystemStopDiffOutput{
-		Stopped: s.resources[beforeDiffField].(bool),
+		Stopped: beforeStopped,
 	}
 	before, _ := json.Marshal(beforeDiffOutput)
 	diff["before"] = string(before)
 
 	afterDiffOutput := sapSystemStopDiffOutput{
-		Stopped: s.resources[afterDiffField].(bool),
+		Stopped: afterStopped,
 	}
 	after, _ := json.Marshal(afterDiffOutput)
 	diff["after"] = string(after)

--- a/pkg/operator/sapsystemstop_v1.go
+++ b/pkg/operator/sapsystemstop_v1.go
@@ -63,7 +63,7 @@ func WithCustomStopSystemInterval(interval time.Duration) SAPSystemStopOption {
 func NewSAPSystemStop(
 	arguments Arguments,
 	operationID string,
-	options OperatorOptions[SAPSystemStop],
+	options Options[SAPSystemStop],
 ) *Executor {
 	sapSystemStop := &SAPSystemStop{
 		baseOperator: newBaseOperator(

--- a/pkg/operator/sapsystemstop_v1.go
+++ b/pkg/operator/sapsystemstop_v1.go
@@ -188,13 +188,19 @@ func (s *SAPSystemStop) operationDiff(_ context.Context) map[string]any {
 	beforeDiffOutput := sapSystemStopDiffOutput{
 		Stopped: beforeStopped,
 	}
-	before, _ := json.Marshal(beforeDiffOutput)
+	before, err := json.Marshal(beforeDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling before diff output: %v", err))
+	}
 	diff["before"] = string(before)
 
 	afterDiffOutput := sapSystemStopDiffOutput{
 		Stopped: afterStopped,
 	}
-	after, _ := json.Marshal(afterDiffOutput)
+	after, err := json.Marshal(afterDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling after diff output: %v", err))
+	}
 	diff["after"] = string(after)
 
 	return diff

--- a/pkg/operator/sapsystemstop_v1_test.go
+++ b/pkg/operator/sapsystemstop_v1_test.go
@@ -30,7 +30,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceNumberMiss
 	ctx := context.Background()
 
 	sapSystemStopOperator := operator.NewSAPSystemStop(
-		operator.OperatorArguments{},
+		operator.Arguments{},
 		"test-op",
 		operator.OperatorOptions[operator.SAPSystemStop]{},
 	)
@@ -46,7 +46,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceNumberInva
 	ctx := context.Background()
 
 	sapSystemStopOperator := operator.NewSAPSystemStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": 0,
 		},
 		"test-op",
@@ -64,7 +64,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopTimeoutInvalid() {
 	ctx := context.Background()
 
 	sapSystemStopOperator := operator.NewSAPSystemStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"timeout":         "value",
 		},
@@ -83,7 +83,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceTypeInvali
 	ctx := context.Background()
 
 	sapSystemStopOperator := operator.NewSAPSystemStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"instance_type":   0,
 		},
@@ -102,7 +102,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceTypeUnknow
 	ctx := context.Background()
 
 	sapSystemStopOperator := operator.NewSAPSystemStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"instance_type":   "unknown",
 		},
@@ -126,7 +126,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopPlanError() {
 		Once()
 
 	sapSystemStopOperator := operator.NewSAPSystemStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"timeout":         300.0,
 		},
@@ -165,7 +165,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopCommitAlreadyStopp
 		Once()
 
 	sapSystemStopOperator := operator.NewSAPSystemStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 		},
 		"test-op",
@@ -235,7 +235,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopCommitAlreadyStopp
 			Once()
 
 		sapSystemStopOperator := operator.NewSAPSystemStop(
-			operator.OperatorArguments{
+			operator.Arguments{
 				"instance_number": "00",
 				"instance_type":   tt.instanceType,
 			},
@@ -303,7 +303,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopCommitStoppingErro
 		NotBefore(rollbackStartSystem)
 
 	sapSystemStopOperator := operator.NewSAPSystemStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 		},
 		"test-op",
@@ -370,7 +370,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopVerifyError() {
 		NotBefore(rollbackStartSystem)
 
 	sapSystemStopOperator := operator.NewSAPSystemStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 		},
 		"test-op",
@@ -411,7 +411,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopVerifyTimeout() {
 		Return(nil, nil)
 
 	sapSystemStopOperator := operator.NewSAPSystemStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"timeout":         0.0,
 		},
@@ -464,7 +464,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopRollbackStoppingEr
 		Return(nil, errors.New("error starting"))
 
 	sapSystemStopOperator := operator.NewSAPSystemStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"instance_type":   "abap",
 		},
@@ -560,7 +560,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopSuccess() {
 			NotBefore(stopSystem)
 
 		sapSystemStopOperator := operator.NewSAPSystemStop(
-			operator.OperatorArguments{
+			operator.Arguments{
 				"instance_number": "00",
 				"instance_type":   tt.instanceType,
 			},
@@ -635,7 +635,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopSuccessMultipleQue
 		Once()
 
 	sapSystemStopOperator := operator.NewSAPSystemStop(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"instance_number": "00",
 			"timeout":         5.0,
 		},

--- a/pkg/operator/sapsystemstop_v1_test.go
+++ b/pkg/operator/sapsystemstop_v1_test.go
@@ -32,7 +32,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceNumberMiss
 	sapSystemStopOperator := operator.NewSAPSystemStop(
 		operator.Arguments{},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStop]{},
+		operator.Options[operator.SAPSystemStop]{},
 	)
 
 	report := sapSystemStopOperator.Run(ctx)
@@ -50,7 +50,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceNumberInva
 			"instance_number": 0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStop]{},
+		operator.Options[operator.SAPSystemStop]{},
 	)
 
 	report := sapSystemStopOperator.Run(ctx)
@@ -69,7 +69,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopTimeoutInvalid() {
 			"timeout":         "value",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStop]{},
+		operator.Options[operator.SAPSystemStop]{},
 	)
 
 	report := sapSystemStopOperator.Run(ctx)
@@ -88,7 +88,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceTypeInvali
 			"instance_type":   0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStop]{},
+		operator.Options[operator.SAPSystemStop]{},
 	)
 
 	report := sapSystemStopOperator.Run(ctx)
@@ -107,7 +107,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopInstanceTypeUnknow
 			"instance_type":   "unknown",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStop]{},
+		operator.Options[operator.SAPSystemStop]{},
 	)
 
 	report := sapSystemStopOperator.Run(ctx)
@@ -131,7 +131,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopPlanError() {
 			"timeout":         300.0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStop]{
+		operator.Options[operator.SAPSystemStop]{
 			OperatorOptions: []operator.Option[operator.SAPSystemStop]{
 				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
 			},
@@ -169,7 +169,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopCommitAlreadyStopp
 			"instance_number": "00",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStop]{
+		operator.Options[operator.SAPSystemStop]{
 			OperatorOptions: []operator.Option[operator.SAPSystemStop]{
 				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
 			},
@@ -240,7 +240,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopCommitAlreadyStopp
 				"instance_type":   tt.instanceType,
 			},
 			"test-op",
-			operator.OperatorOptions[operator.SAPSystemStop]{
+			operator.Options[operator.SAPSystemStop]{
 				OperatorOptions: []operator.Option[operator.SAPSystemStop]{
 					operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
 				},
@@ -307,7 +307,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopCommitStoppingErro
 			"instance_number": "00",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStop]{
+		operator.Options[operator.SAPSystemStop]{
 			OperatorOptions: []operator.Option[operator.SAPSystemStop]{
 				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
 			},
@@ -374,7 +374,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopVerifyError() {
 			"instance_number": "00",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStop]{
+		operator.Options[operator.SAPSystemStop]{
 			OperatorOptions: []operator.Option[operator.SAPSystemStop]{
 				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
 			},
@@ -416,7 +416,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopVerifyTimeout() {
 			"timeout":         0.0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStop]{
+		operator.Options[operator.SAPSystemStop]{
 			OperatorOptions: []operator.Option[operator.SAPSystemStop]{
 				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
 				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemInterval(0 * time.Second)),
@@ -469,7 +469,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopRollbackStoppingEr
 			"instance_type":   "abap",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStop]{
+		operator.Options[operator.SAPSystemStop]{
 			OperatorOptions: []operator.Option[operator.SAPSystemStop]{
 				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
 			},
@@ -565,7 +565,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopSuccess() {
 				"instance_type":   tt.instanceType,
 			},
 			"test-op",
-			operator.OperatorOptions[operator.SAPSystemStop]{
+			operator.Options[operator.SAPSystemStop]{
 				OperatorOptions: []operator.Option[operator.SAPSystemStop]{
 					operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
 				},
@@ -640,7 +640,7 @@ func (suite *SAPSystemStopOperatorTestSuite) TestSAPSystemStopSuccessMultipleQue
 			"timeout":         5.0,
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SAPSystemStop]{
+		operator.Options[operator.SAPSystemStop]{
 			OperatorOptions: []operator.Option[operator.SAPSystemStop]{
 				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemSapcontrol(suite.mockSapcontrol)),
 				operator.Option[operator.SAPSystemStop](operator.WithCustomStopSystemInterval(0 * time.Second)),

--- a/pkg/operator/saptuneapplysolution_v1.go
+++ b/pkg/operator/saptuneapplysolution_v1.go
@@ -14,7 +14,7 @@ type saptuneSolutionArguments struct {
 	solution string
 }
 
-func parseSaptuneSolutionArguments(rawArguments OperatorArguments) (*saptuneSolutionArguments, error) {
+func parseSaptuneSolutionArguments(rawArguments Arguments) (*saptuneSolutionArguments, error) {
 	argument, found := rawArguments["solution"]
 	if !found {
 		return nil, errors.New("argument solution not provided, could not use the operator")
@@ -87,7 +87,7 @@ func WithSaptuneClientApply(saptuneClient saptune.Saptune) SaptuneApplySolutionO
 }
 
 func NewSaptuneApplySolution(
-	arguments OperatorArguments,
+	arguments Arguments,
 	operationID string,
 	options OperatorOptions[SaptuneApplySolution],
 ) *Executor {

--- a/pkg/operator/saptuneapplysolution_v1.go
+++ b/pkg/operator/saptuneapplysolution_v1.go
@@ -201,13 +201,19 @@ func (sa *SaptuneApplySolution) operationDiff(_ context.Context) map[string]any 
 	beforeDiffOutput := saptuneOperationDiffOutput{
 		Solution: beforeSolution,
 	}
-	before, _ := json.Marshal(beforeDiffOutput)
+	before, err := json.Marshal(beforeDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling before diff output: %v", err))
+	}
 	diff[beforeDiffField] = string(before)
 
 	afterDiffOutput := saptuneOperationDiffOutput{
 		Solution: afterSolution,
 	}
-	after, _ := json.Marshal(afterDiffOutput)
+	after, err := json.Marshal(afterDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling after diff output: %v", err))
+	}
 	diff[afterDiffField] = string(after)
 
 	return diff

--- a/pkg/operator/saptuneapplysolution_v1.go
+++ b/pkg/operator/saptuneapplysolution_v1.go
@@ -89,7 +89,7 @@ func WithSaptuneClientApply(saptuneClient saptune.Saptune) SaptuneApplySolutionO
 func NewSaptuneApplySolution(
 	arguments Arguments,
 	operationID string,
-	options OperatorOptions[SaptuneApplySolution],
+	options Options[SaptuneApplySolution],
 ) *Executor {
 	saptuneApply := &SaptuneApplySolution{
 		baseOperator: newBaseOperator(

--- a/pkg/operator/saptuneapplysolution_v1.go
+++ b/pkg/operator/saptuneapplysolution_v1.go
@@ -52,19 +52,22 @@ type SaptuneApplySolutionOption Option[SaptuneApplySolution]
 //
 // - PLAN:
 //   The operator checks for the presence of the saptune binary and verifies its version.
-//   The minimum required version is 3.1.0. If saptune is not installed or the version does not meet the minimum requirement,
-//   the operation will fail.
+//   The minimum required version is 3.1.0. If saptune is not installed or the version does not meet the minimum
+//   requirement, the operation will fail.
+//
 //   The initially applied solution, if any, is collected as the "before" diff.
 //   The operator checks if the requested solution is already applied. If it is, no action is taken,
 //   ensuring idempotency without returning an error.
 //
 // - COMMIT:
-//   If there is any other solution already applied, an error is raised, because only one solution can be applied at a time.
+//   If there is any other solution already applied, an error is raised, because only one solution can be
+//   applied at a time.
 // 	 If otherwise there is no solution applied the saptune command to apply the solution will be executed.
 //
 // - VERIFY:
 //   The operator verifies whether the solution has been correctly applied to the system.
-//   If not, an error is raised. If successful, the current state of the applied solution is collected as the "after" diff.
+//   If not, an error is raised. If successful, the current state of the applied solution is collected as
+//   the "after" diff.
 //
 // - ROLLBACK:
 //   If an error occurs during the COMMIT or VERIFY phase, the saptune revert command is executed

--- a/pkg/operator/saptuneapplysolution_v1.go
+++ b/pkg/operator/saptuneapplysolution_v1.go
@@ -186,14 +186,26 @@ func (sa *SaptuneApplySolution) rollback(ctx context.Context) error {
 func (sa *SaptuneApplySolution) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
+	beforeSolution, ok := sa.resources[beforeDiffField].(string)
+	if !ok {
+		panic(fmt.Sprintf("invalid beforeSolution value: cannot parse '%s' to string",
+			sa.resources[beforeDiffField]))
+	}
+
+	afterSolution, ok := sa.resources[afterDiffField].(string)
+	if !ok {
+		panic(fmt.Sprintf("invalid afterSolution value: cannot parse '%s' to string",
+			sa.resources[afterDiffField]))
+	}
+
 	beforeDiffOutput := saptuneOperationDiffOutput{
-		Solution: sa.resources[beforeDiffField].(string),
+		Solution: beforeSolution,
 	}
 	before, _ := json.Marshal(beforeDiffOutput)
 	diff[beforeDiffField] = string(before)
 
 	afterDiffOutput := saptuneOperationDiffOutput{
-		Solution: sa.resources[afterDiffField].(string),
+		Solution: afterSolution,
 	}
 	after, _ := json.Marshal(afterDiffOutput)
 	diff[afterDiffField] = string(after)

--- a/pkg/operator/saptuneapplysolution_v1.go
+++ b/pkg/operator/saptuneapplysolution_v1.go
@@ -183,6 +183,9 @@ func (sa *SaptuneApplySolution) rollback(ctx context.Context) error {
 	return sa.saptune.RevertSolution(ctx, sa.parsedArguments.solution)
 }
 
+//	operationDiff needs to be refactored, ignoring duplication issues for now
+//
+// nolint: dupl
 func (sa *SaptuneApplySolution) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/pkg/operator/saptuneapplysolution_v1_test.go
+++ b/pkg/operator/saptuneapplysolution_v1_test.go
@@ -31,7 +31,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlan
 			"foo": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneApplySolution]{},
+		operator.Options[operator.SaptuneApplySolution]{},
 	)
 
 	report := saptuneSolutionApplyOperator.Run(ctx)
@@ -49,7 +49,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlan
 			"solution": "",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneApplySolution]{},
+		operator.Options[operator.SaptuneApplySolution]{},
 	)
 
 	report := saptuneSolutionApplyOperator.Run(ctx)
@@ -73,7 +73,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlan
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneApplySolution]{
+		operator.Options[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
 				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
@@ -108,7 +108,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlan
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneApplySolution]{
+		operator.Options[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
 				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
@@ -143,7 +143,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionComm
 			"solution": "S4HANA-DBSERVER",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneApplySolution]{
+		operator.Options[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
 				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
@@ -197,7 +197,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionComm
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneApplySolution]{
+		operator.Options[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
 				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
@@ -251,7 +251,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionComm
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneApplySolution]{
+		operator.Options[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
 				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
@@ -312,7 +312,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVeri
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneApplySolution]{
+		operator.Options[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
 				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
@@ -372,7 +372,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVeri
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneApplySolution]{
+		operator.Options[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
 				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
@@ -437,7 +437,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVeri
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneApplySolution]{
+		operator.Options[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
 				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
@@ -501,7 +501,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionErro
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneApplySolution]{
+		operator.Options[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
 				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
@@ -552,7 +552,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionSucc
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneApplySolution]{
+		operator.Options[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
 				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},
@@ -592,7 +592,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionSucc
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneApplySolution]{
+		operator.Options[operator.SaptuneApplySolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneApplySolution]{
 				operator.Option[operator.SaptuneApplySolution](operator.WithSaptuneClientApply(suite.mockSaptuneClient)),
 			},

--- a/pkg/operator/saptuneapplysolution_v1_test.go
+++ b/pkg/operator/saptuneapplysolution_v1_test.go
@@ -27,7 +27,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlan
 	ctx := context.Background()
 
 	saptuneSolutionApplyOperator := operator.NewSaptuneApplySolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"foo": "HANA",
 		},
 		"test-op",
@@ -45,7 +45,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlan
 	ctx := context.Background()
 
 	saptuneSolutionApplyOperator := operator.NewSaptuneApplySolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "",
 		},
 		"test-op",
@@ -69,7 +69,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlan
 		Once()
 
 	saptuneSolutionApplyOperator := operator.NewSaptuneApplySolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -104,7 +104,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionPlan
 		Once()
 
 	saptuneSolutionApplyOperator := operator.NewSaptuneApplySolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -139,7 +139,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionComm
 		Once()
 
 	saptuneSolutionApplyOperator := operator.NewSaptuneApplySolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "S4HANA-DBSERVER",
 		},
 		"test-op",
@@ -193,7 +193,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionComm
 		Once()
 
 	saptuneSolutionApplyOperator := operator.NewSaptuneApplySolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -247,7 +247,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionComm
 		Once()
 
 	saptuneSolutionApplyOperator := operator.NewSaptuneApplySolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -308,7 +308,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVeri
 		Once()
 
 	saptuneSolutionApplyOperator := operator.NewSaptuneApplySolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -368,7 +368,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVeri
 		Once()
 
 	saptuneSolutionApplyOperator := operator.NewSaptuneApplySolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -433,7 +433,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionVeri
 		Once()
 
 	saptuneSolutionApplyOperator := operator.NewSaptuneApplySolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -497,7 +497,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionErro
 		Once()
 
 	saptuneSolutionApplyOperator := operator.NewSaptuneApplySolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -548,7 +548,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionSucc
 		Once()
 
 	saptuneSolutionApplyOperator := operator.NewSaptuneApplySolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -588,7 +588,7 @@ func (suite *SaptuneApplySolutionOperatorTestSuite) TestSaptuneApplySolutionSucc
 		Once()
 
 	saptuneSolutionApplyOperator := operator.NewSaptuneApplySolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",

--- a/pkg/operator/saptunechangesolution_v1.go
+++ b/pkg/operator/saptunechangesolution_v1.go
@@ -174,13 +174,19 @@ func (sc *SaptuneChangeSolution) operationDiff(_ context.Context) map[string]any
 	beforeDiffOutput := saptuneOperationDiffOutput{
 		Solution: beforeSolution,
 	}
-	before, _ := json.Marshal(beforeDiffOutput)
+	before, err := json.Marshal(beforeDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling before diff output: %v", err))
+	}
 	diff[beforeDiffField] = string(before)
 
 	afterDiffOutput := saptuneOperationDiffOutput{
 		Solution: afterSolution,
 	}
-	after, _ := json.Marshal(afterDiffOutput)
+	after, err := json.Marshal(afterDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling after diff output: %v", err))
+	}
 	diff[afterDiffField] = string(after)
 
 	return diff

--- a/pkg/operator/saptunechangesolution_v1.go
+++ b/pkg/operator/saptunechangesolution_v1.go
@@ -25,14 +25,18 @@ type SaptuneChangeSolutionOption Option[SaptuneChangeSolution]
 // - COMMIT:
 //   If there is no other solution already applied, an error is raised,
 //   effectively allowing a transition from a solution to another but not from no solution to some solution.
-// 	 If otherwise there is a solution applied that is not the currently applied one the saptune command to change the solution will be executed.
+// 	 If otherwise there is a solution applied that is not the currently applied one the saptune command to change the
+//   solution will be executed.
 //
 // - VERIFY:
-//   The operator verifies whether the solution has been correctly changed to the requested one. If not, an error is raised.
+//   The operator verifies whether the solution has been correctly changed to the requested one.
+//   If not, an error is raised.
+//
 //   On success, the current state of the applied solution is collected as the "after" diff.
 //
 // - ROLLBACK:
-//   If an error occurs during the COMMIT or VERIFY phase, the saptune solution is changed back to the initially applied one.
+//   If an error occurs during the COMMIT or VERIFY phase, the saptune solution is changed back to the initially
+//   applied one.
 
 type SaptuneChangeSolution struct {
 	baseOperator
@@ -53,7 +57,10 @@ func NewSaptuneChangeSolution(
 ) *Executor {
 	saptuneChange := &SaptuneChangeSolution{
 		baseOperator: newBaseOperator(
-			SaptuneChangeSolutionOperatorName, operationID, arguments, options.BaseOperatorOptions...,
+			SaptuneChangeSolutionOperatorName,
+			operationID,
+			arguments,
+			options.BaseOperatorOptions...,
 		),
 	}
 
@@ -144,7 +151,8 @@ func (sc *SaptuneChangeSolution) rollback(ctx context.Context) error {
 		return nil
 	}
 
-	sc.logger.Info("Changing solution to the initially applied one", "appliedSolution", initiallyAppliedSolution)
+	sc.logger.Info("Changing solution to the initially applied one",
+		"appliedSolution", initiallyAppliedSolution)
 	return sc.saptune.ChangeSolution(ctx, initiallyAppliedSolution)
 }
 

--- a/pkg/operator/saptunechangesolution_v1.go
+++ b/pkg/operator/saptunechangesolution_v1.go
@@ -49,7 +49,7 @@ func WithSaptuneClientChange(saptuneClient saptune.Saptune) SaptuneChangeSolutio
 func NewSaptuneChangeSolution(
 	arguments Arguments,
 	operationID string,
-	options OperatorOptions[SaptuneChangeSolution],
+	options Options[SaptuneChangeSolution],
 ) *Executor {
 	saptuneChange := &SaptuneChangeSolution{
 		baseOperator: newBaseOperator(

--- a/pkg/operator/saptunechangesolution_v1.go
+++ b/pkg/operator/saptunechangesolution_v1.go
@@ -156,6 +156,9 @@ func (sc *SaptuneChangeSolution) rollback(ctx context.Context) error {
 	return sc.saptune.ChangeSolution(ctx, initiallyAppliedSolution)
 }
 
+//	operationDiff needs to be refactored, ignoring duplication issues for now
+//
+// nolint: dupl
 func (sc *SaptuneChangeSolution) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 

--- a/pkg/operator/saptunechangesolution_v1.go
+++ b/pkg/operator/saptunechangesolution_v1.go
@@ -148,17 +148,17 @@ func (sc *SaptuneChangeSolution) rollback(ctx context.Context) error {
 	return sc.saptune.ChangeSolution(ctx, initiallyAppliedSolution)
 }
 
-func (sa *SaptuneChangeSolution) operationDiff(_ context.Context) map[string]any {
+func (sc *SaptuneChangeSolution) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
 	beforeDiffOutput := saptuneOperationDiffOutput{
-		Solution: sa.resources[beforeDiffField].(string),
+		Solution: sc.resources[beforeDiffField].(string),
 	}
 	before, _ := json.Marshal(beforeDiffOutput)
 	diff[beforeDiffField] = string(before)
 
 	afterDiffOutput := saptuneOperationDiffOutput{
-		Solution: sa.resources[afterDiffField].(string),
+		Solution: sc.resources[afterDiffField].(string),
 	}
 	after, _ := json.Marshal(afterDiffOutput)
 	diff[afterDiffField] = string(after)

--- a/pkg/operator/saptunechangesolution_v1.go
+++ b/pkg/operator/saptunechangesolution_v1.go
@@ -47,7 +47,7 @@ func WithSaptuneClientChange(saptuneClient saptune.Saptune) SaptuneChangeSolutio
 }
 
 func NewSaptuneChangeSolution(
-	arguments OperatorArguments,
+	arguments Arguments,
 	operationID string,
 	options OperatorOptions[SaptuneChangeSolution],
 ) *Executor {

--- a/pkg/operator/saptunechangesolution_v1.go
+++ b/pkg/operator/saptunechangesolution_v1.go
@@ -159,14 +159,26 @@ func (sc *SaptuneChangeSolution) rollback(ctx context.Context) error {
 func (sc *SaptuneChangeSolution) operationDiff(_ context.Context) map[string]any {
 	diff := make(map[string]any)
 
+	beforeSolution, ok := sc.resources[beforeDiffField].(string)
+	if !ok {
+		panic(fmt.Sprintf("invalid beforeSolution value: cannot parse '%s' to string",
+			sc.resources[beforeDiffField]))
+	}
+
+	afterSolution, ok := sc.resources[afterDiffField].(string)
+	if !ok {
+		panic(fmt.Sprintf("invalid afterSolution value: cannot parse '%s' to string",
+			sc.resources[afterDiffField]))
+	}
+
 	beforeDiffOutput := saptuneOperationDiffOutput{
-		Solution: sc.resources[beforeDiffField].(string),
+		Solution: beforeSolution,
 	}
 	before, _ := json.Marshal(beforeDiffOutput)
 	diff[beforeDiffField] = string(before)
 
 	afterDiffOutput := saptuneOperationDiffOutput{
-		Solution: sc.resources[afterDiffField].(string),
+		Solution: afterSolution,
 	}
 	after, _ := json.Marshal(afterDiffOutput)
 	diff[afterDiffField] = string(after)

--- a/pkg/operator/saptunechangesolution_v1_test.go
+++ b/pkg/operator/saptunechangesolution_v1_test.go
@@ -31,7 +31,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionPl
 			"foo": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneChangeSolution]{},
+		operator.Options[operator.SaptuneChangeSolution]{},
 	)
 
 	report := saptuneSolutionChangeOperator.Run(ctx)
@@ -49,7 +49,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionPl
 			"solution": "",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneChangeSolution]{},
+		operator.Options[operator.SaptuneChangeSolution]{},
 	)
 
 	report := saptuneSolutionChangeOperator.Run(ctx)
@@ -73,7 +73,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionPl
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+		operator.Options[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
 				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
@@ -108,7 +108,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionPl
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+		operator.Options[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
 				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
@@ -144,7 +144,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCo
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+		operator.Options[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
 				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
@@ -198,7 +198,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCo
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+		operator.Options[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
 				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
@@ -251,7 +251,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCo
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+		operator.Options[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
 				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
@@ -313,7 +313,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+		operator.Options[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
 				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
@@ -375,7 +375,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+		operator.Options[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
 				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
@@ -438,7 +438,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+		operator.Options[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
 				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
@@ -500,7 +500,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+		operator.Options[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
 				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
@@ -535,7 +535,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionSu
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+		operator.Options[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
 				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},
@@ -592,7 +592,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionSu
 			"solution": "HANA",
 		},
 		"test-op",
-		operator.OperatorOptions[operator.SaptuneChangeSolution]{
+		operator.Options[operator.SaptuneChangeSolution]{
 			OperatorOptions: []operator.Option[operator.SaptuneChangeSolution]{
 				operator.Option[operator.SaptuneChangeSolution](operator.WithSaptuneClientChange(suite.mockSaptuneClient)),
 			},

--- a/pkg/operator/saptunechangesolution_v1_test.go
+++ b/pkg/operator/saptunechangesolution_v1_test.go
@@ -27,7 +27,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionPl
 	ctx := context.Background()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"foo": "HANA",
 		},
 		"test-op",
@@ -45,7 +45,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionPl
 	ctx := context.Background()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "",
 		},
 		"test-op",
@@ -69,7 +69,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionPl
 		Once()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -104,7 +104,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionPl
 		Once()
 
 	saptuneSolutionApplyOperator := operator.NewSaptuneChangeSolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -140,7 +140,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCo
 		Once()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -194,7 +194,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCo
 		Once()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -247,7 +247,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionCo
 		Once()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -309,7 +309,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		Once()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -371,7 +371,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		Once()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -434,7 +434,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		Once()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -496,7 +496,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionVe
 		Once()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -531,7 +531,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionSu
 		Once()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",
@@ -588,7 +588,7 @@ func (suite *SaptuneChangeSolutionOperatorTestSuite) TestSaptuneChangeSolutionSu
 		Once()
 
 	saptuneSolutionChangeOperator := operator.NewSaptuneChangeSolution(
-		operator.OperatorArguments{
+		operator.Arguments{
 			"solution": "HANA",
 		},
 		"test-op",

--- a/pkg/operator/servicedisable_v1.go
+++ b/pkg/operator/servicedisable_v1.go
@@ -51,7 +51,7 @@ func NewServiceDisable(
 	name string,
 	arguments Arguments,
 	operationID string,
-	options OperatorOptions[ServiceDisable],
+	options Options[ServiceDisable],
 ) *Executor {
 	serviceDisable := &ServiceDisable{
 		baseOperator: newBaseOperator(

--- a/pkg/operator/servicedisable_v1.go
+++ b/pkg/operator/servicedisable_v1.go
@@ -49,7 +49,7 @@ func WithServiceToDisable(service string) ServiceDisableOption {
 
 func NewServiceDisable(
 	name string,
-	arguments OperatorArguments,
+	arguments Arguments,
 	operationID string,
 	options OperatorOptions[ServiceDisable],
 ) *Executor {

--- a/pkg/operator/servicedisable_v1.go
+++ b/pkg/operator/servicedisable_v1.go
@@ -125,10 +125,10 @@ func (sd *ServiceDisable) rollback(ctx context.Context) error {
 	return sd.systemdConnector.Enable(ctx, sd.service)
 }
 
-func (sd *ServiceDisable) operationDiff(ctx context.Context) map[string]any {
+func (sd *ServiceDisable) operationDiff(_ context.Context) map[string]any {
 	return computeOperationDiff(sd.resources)
 }
 
-func (sd *ServiceDisable) after(ctx context.Context) {
+func (sd *ServiceDisable) after(_ context.Context) {
 	sd.systemdConnector.Close()
 }

--- a/pkg/operator/servicedisable_v1.go
+++ b/pkg/operator/servicedisable_v1.go
@@ -30,12 +30,12 @@ type ServiceDisableOption Option[ServiceDisable]
 
 type ServiceDisable struct {
 	baseOperator
-	systemdLoader    systemd.SystemdLoader
+	systemdLoader    systemd.Loader
 	systemdConnector systemd.Systemd
 	service          string
 }
 
-func WithCustomServiceDisableSystemdLoader(systemdLoader systemd.SystemdLoader) ServiceDisableOption {
+func WithCustomServiceDisableSystemdLoader(systemdLoader systemd.Loader) ServiceDisableOption {
 	return func(sd *ServiceDisable) {
 		sd.systemdLoader = systemdLoader
 	}

--- a/pkg/operator/servicedisable_v1_test.go
+++ b/pkg/operator/servicedisable_v1_test.go
@@ -25,7 +25,7 @@ func buildServiceDisableOperator(suite *ServiceDisableOperatorTestSuite) operato
 		"servicedisableoperator",
 		operator.Arguments{},
 		"test-op",
-		operator.OperatorOptions[operator.ServiceDisable]{
+		operator.Options[operator.ServiceDisable]{
 			BaseOperatorOptions: []operator.BaseOperatorOption{
 				operator.WithCustomLogger(suite.logger),
 			},

--- a/pkg/operator/servicedisable_v1_test.go
+++ b/pkg/operator/servicedisable_v1_test.go
@@ -23,7 +23,7 @@ type ServiceDisableOperatorTestSuite struct {
 func buildServiceDisableOperator(suite *ServiceDisableOperatorTestSuite) operator.Operator {
 	return operator.NewServiceDisable(
 		"servicedisableoperator",
-		operator.OperatorArguments{},
+		operator.Arguments{},
 		"test-op",
 		operator.OperatorOptions[operator.ServiceDisable]{
 			BaseOperatorOptions: []operator.BaseOperatorOption{

--- a/pkg/operator/serviceenable_v1.go
+++ b/pkg/operator/serviceenable_v1.go
@@ -38,12 +38,12 @@ type ServiceEnableOption Option[ServiceEnable]
 
 type ServiceEnable struct {
 	baseOperator
-	systemdLoader    systemd.SystemdLoader
+	systemdLoader    systemd.Loader
 	systemdConnector systemd.Systemd
 	service          string
 }
 
-func WithCustomServiceEnableSystemdLoader(systemdLoader systemd.SystemdLoader) ServiceEnableOption {
+func WithCustomServiceEnableSystemdLoader(systemdLoader systemd.Loader) ServiceEnableOption {
 	return func(se *ServiceEnable) {
 		se.systemdLoader = systemdLoader
 	}

--- a/pkg/operator/serviceenable_v1.go
+++ b/pkg/operator/serviceenable_v1.go
@@ -144,14 +144,26 @@ func (se *ServiceEnable) after(_ context.Context) {
 func computeOperationDiff(resources map[string]any) map[string]any {
 	diff := make(map[string]any)
 
+	beforeEnabled, ok := resources[beforeDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid beforeEnabled value: cannot parse '%s' to bool",
+			resources[beforeDiffField]))
+	}
+
+	afterEnabled, ok := resources[afterDiffField].(bool)
+	if !ok {
+		panic(fmt.Sprintf("invalid afterEnabled value: cannot parse '%s' to bool",
+			resources[afterDiffField]))
+	}
+
 	beforeDiffOutput := serviceEnablementDiffOutput{
-		Enabled: resources[beforeDiffField].(bool),
+		Enabled: beforeEnabled,
 	}
 	before, _ := json.Marshal(beforeDiffOutput)
 	diff[beforeDiffField] = string(before)
 
 	afterDiffOutput := serviceEnablementDiffOutput{
-		Enabled: resources[afterDiffField].(bool),
+		Enabled: afterEnabled,
 	}
 	after, _ := json.Marshal(afterDiffOutput)
 	diff[afterDiffField] = string(after)

--- a/pkg/operator/serviceenable_v1.go
+++ b/pkg/operator/serviceenable_v1.go
@@ -57,7 +57,7 @@ func WithServiceToEnable(service string) ServiceEnableOption {
 
 func NewServiceEnable(
 	name string,
-	arguments OperatorArguments,
+	arguments Arguments,
 	operationID string,
 	options OperatorOptions[ServiceEnable],
 ) *Executor {

--- a/pkg/operator/serviceenable_v1.go
+++ b/pkg/operator/serviceenable_v1.go
@@ -159,13 +159,19 @@ func computeOperationDiff(resources map[string]any) map[string]any {
 	beforeDiffOutput := serviceEnablementDiffOutput{
 		Enabled: beforeEnabled,
 	}
-	before, _ := json.Marshal(beforeDiffOutput)
+	before, err := json.Marshal(beforeDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling before diff output: %v", err))
+	}
 	diff[beforeDiffField] = string(before)
 
 	afterDiffOutput := serviceEnablementDiffOutput{
 		Enabled: afterEnabled,
 	}
-	after, _ := json.Marshal(afterDiffOutput)
+	after, err := json.Marshal(afterDiffOutput)
+	if err != nil {
+		panic(fmt.Sprintf("error marshalling after diff output: %v", err))
+	}
 	diff[afterDiffField] = string(after)
 
 	return diff

--- a/pkg/operator/serviceenable_v1.go
+++ b/pkg/operator/serviceenable_v1.go
@@ -59,7 +59,7 @@ func NewServiceEnable(
 	name string,
 	arguments Arguments,
 	operationID string,
-	options OperatorOptions[ServiceEnable],
+	options Options[ServiceEnable],
 ) *Executor {
 	serviceEnable := &ServiceEnable{
 		baseOperator: newBaseOperator(

--- a/pkg/operator/serviceenable_v1.go
+++ b/pkg/operator/serviceenable_v1.go
@@ -133,7 +133,7 @@ func (se *ServiceEnable) rollback(ctx context.Context) error {
 	return se.systemdConnector.Disable(ctx, se.service)
 }
 
-func (se *ServiceEnable) operationDiff(ctx context.Context) map[string]any {
+func (se *ServiceEnable) operationDiff(_ context.Context) map[string]any {
 	return computeOperationDiff(se.resources)
 }
 

--- a/pkg/operator/serviceenable_v1_test.go
+++ b/pkg/operator/serviceenable_v1_test.go
@@ -25,7 +25,7 @@ func buildServiceEnableOperator(suite *ServiceEnableOperatorTestSuite) operator.
 		"serviceenableoperator",
 		operator.Arguments{},
 		"test-op",
-		operator.OperatorOptions[operator.ServiceEnable]{
+		operator.Options[operator.ServiceEnable]{
 			BaseOperatorOptions: []operator.BaseOperatorOption{
 				operator.WithCustomLogger(suite.logger),
 			},

--- a/pkg/operator/serviceenable_v1_test.go
+++ b/pkg/operator/serviceenable_v1_test.go
@@ -23,7 +23,7 @@ type ServiceEnableOperatorTestSuite struct {
 func buildServiceEnableOperator(suite *ServiceEnableOperatorTestSuite) operator.Operator {
 	return operator.NewServiceEnable(
 		"serviceenableoperator",
-		operator.OperatorArguments{},
+		operator.Arguments{},
 		"test-op",
 		operator.OperatorOptions[operator.ServiceEnable]{
 			BaseOperatorOptions: []operator.BaseOperatorOption{

--- a/test/helpers/fixtures.go
+++ b/test/helpers/fixtures.go
@@ -7,12 +7,12 @@ import (
 	"sync"
 )
 
-var (
-	fixturesFolder     string
-	fixturesFolderOnce sync.Once
-)
-
 func getFixturesFolder() string {
+	var (
+		fixturesFolder     string
+		fixturesFolderOnce sync.Once
+	)
+
 	fixturesFolderOnce.Do(func() {
 		_, filename, _, ok := runtime.Caller(0)
 		if !ok {


### PR DESCRIPTION
Adding linter configuration to the project. The same configuration from [Trento Agent](https://github.com/trento-project/agent/blob/2b95b234cbfd5d3781ed251b4c5b92b152426311/.golangci.yaml) has been used, so that in the future the two codebases can eventually merge.

The work focused primarily on having the lint stage pass without any structural change in the codebase. When possible, it has been a matter of moving/renaming/formatting instructions only; structural changes are left for further iterations.

### Caveats
- As most of the code is under the same package (`operator`), variable naming was used to create a sort of _namespacing_; this clutters with some lint rules (namely: exported, revive), we might want to handle separation of concerns using packages (which is the idiomatic way in Go)
- Some code is duplicated in tests; we can ignore it, as we promote explicitness over abstraction in tests.
- Function `operationDiff`'s signature expects no error, still, the concrete implementations may fail; this PR handles the error explicitly by raising a panic. Let's consider refactoring the interface to handle errors properly
- Again, the function `operatorDiff` is duplicated in many cases; as a sensible rethinking of the function is needed, the duplication check is skipped for now. 

### Fixed rules
- fix: unused-parameter (c3c60ee)
- fix: var-naming: don't use ALL_CAPS in Go names (revive) (70f64bb)
- fix: (testpackage) (053b247)
- fix: receiver-naming (revive) (867123a)
- fix: exported: type name will be used as cluster.ClusterClient by other packages, and that stutters; consider calling this Client (revive) (4d84cb8)
- fix exported: type name will be used as dbus.DbusConnector by other packages, and that stutters; consider calling this Connector (revive) (7b6b28d)
- fix: exported: type name will be used as systemd.SystemdConnector by other packages, and that stutters; consider calling this Connector (revive) (83947cf)
- fix: exported: type name will be used as systemd.SystemdConnectorOption by other packages, and that stutters; consider calling this ConnectorOption (revive) (146aa76)
- fix: exported: type name will be used as systemd.SystemdLoader by other packages, and that stutters; consider calling this Loader (revive) (b5dc0d7)
- fix: exported: type name will be used as operator.OperatorPhases by other packages, and that stutters; consider calling this Phases (revive) (b05d503)
- fix: exported: type name will be used as operator.OperatorArguments by other packages, and that stutters; consider calling this Arguments (revive) (1ebb448)
- fix: exported: type name will be used as operator.OperatorOptions by other packages, and that stutters; consider calling this Options (revive) (279c88c)
- fix: exported: type name will be used as operator.OperatorNotFoundError by other packages, and that stutters; consider calling this NotFoundError (revive) (f563429)
- fix: exported: type name will be used as operator.OperatorBuilder by other packages, and that stutters; consider calling this Builder (revive) (1e65c5b)
- fix exported: type name will be used as operator.OperatorBuildersTree by other packages, and that stutters; consider calling this BuildersTree (revive) (3a704ec)
- fix: The line is xxx characters long, which exceeds the maximum of 120 characters (lll) (7a2e034)
- fix: (gochecknoglobals) (6cdf522)
- fix: appendAssign: append result not assigned to the same slice (gocritic) (a18e603)
- fix: type assertion must be checked (forcetypeassert) (4874d18)
- fix: redefines-builtin-id: redefinition of the built-in type error (revive) (dd6ca79)
- fix: ifElseChain: rewrite if-else to switch statement (gocritic) (404b7d0)
- fix: non-wrapping format verb for fmt.Errorf. Use  to format errors (errorlint) (4c11933)
- fix: is always nil (unparam) (3cad71b)
- fix: string  has 7 occurrences, make it a constant (goconst) (617e230)
- fix: Error return value of  is not checked (errchkjson) (0da526a)

### Ignored/skipped
- ignore var-naming issues on generated code (59cf37e)
- ignore exported issues on generated code (053bf1b)
- ignore dupl on test files (c8c6c76)
- skip dupl on operationDiff (74b4920)